### PR TITLE
TRCL-3095 : Orderbook asks lost the animation

### DIFF
--- a/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/Components/Orderbook/dydxOrderbookSideView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/Components/Orderbook/dydxOrderbookSideView.swift
@@ -96,34 +96,19 @@ public class dydxOrderbookSideViewModel: PlatformViewModel, Equatable {
                 let additionalLineHeight: CGFloat = intendedLineHeight * (numLinesToDisplayExact.truncatingRemainder(dividingBy: 1)) / numLinesToDisplayFloored
                 let actualLineHeight: CGFloat = intendedLineHeight + additionalLineHeight
 
-                switch self.displayStyle {
-                case .sideBySide:
+                LazyVStack(spacing: spacing) {
 
-                    LazyVStack(spacing: spacing) {
-
-                        ForEach(lines.prefix(numLinesToDisplayInt), id: \.self.id) { line in
-                            AnyView(
-                                self.cell(line: line, maxDepth: maxDepth, fixedHeight: actualLineHeight)
-                            )
-                            .id(line.id)
-                        }
-
-                        Spacer()
+                    ForEach(lines.prefix(numLinesToDisplayInt), id: \.self.id) { line in
+                        AnyView(
+                            self.cell(line: line, maxDepth: maxDepth, fixedHeight: actualLineHeight)
+                        )
+                        .id(line.id)
                     }
-                    .topAligned()
 
-                case .topDown:
-                    LazyVStack(spacing: spacing) {
-                        ForEach(lines.prefix(numLinesToDisplayInt), id: \.self.id) { line in
-                            AnyView(
-                                self.cell(line: line, maxDepth: maxDepth, fixedHeight: actualLineHeight)
-                            )
-                            .id(line.id)
-                        }
-                        Spacer()
-                    }
-                    .topAligned()
+                    Spacer()
                 }
+                .animation(.default, value: lines) // Here the animation is applied to the LazyVStack
+                .topAligned()
             }
         }
     }


### PR DESCRIPTION
## Links
Linear Ticket: [TRCL-3095 : Orderbook asks lost the animation](https://linear.app/dydx/issue/TRCL-3095/orderbook-asks-lost-the-animation)



<br/>

## Description / Intuition
- adds back asks animation functionality. (adds an `animation(...)` line)
- refactors duplicated code

tested on both top down and side-by-side orderbook displays



<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/ac3c1839-32f6-4d5a-b57a-623a45e2fb18"> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/117a4a88-7355-4219-aa0d-843ba0f41b17"> |




<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
