### PR TITLE
TRCL-3055 : Market: differences in text color? make both secondary

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,4 +1,4 @@
-## Links
+## Links (dYdX Internal Use Only)
 Linear Ticket: _[Provide link to Linear ticket issue]_
 
 Figma Design: _[Provide link to Figma design here if applicable]_
@@ -20,9 +20,9 @@ _Provide a clear and concise description of the fix(es) or change(s) you made. I
 
 | Before | After |
 |--------|-------|
-| ![before image](url_here){: width="300px" } | ![after image](url_here){: width="300px" } |
+| <img src=""> | <img src=""> |
+| <video src=""> | <video src=""> |
 
-_**Note**: Replace `url_here` with the URL of your image and adjust `width` accordingly._
 
 
 
@@ -36,11 +36,3 @@ _**Note**: Replace `url_here` with the URL of your image and adjust `width` acco
 - [ ] Refactoring or Technical Debt
 - [ ] Documentation update
 - [ ] Other (please describe: )
-
-
-
-
-<br/>
-
-### Additional Comments (optional)
-Provide any additional comments or context about the changes here.

--- a/dydx/dydxViews/dydxViews/_v4/MarketInfo/Components/Resources/dydxMarketResourcesView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/MarketInfo/Components/Resources/dydxMarketResourcesView.swift
@@ -83,13 +83,12 @@ public class dydxMarketResourcesViewModel: PlatformViewModel {
                                                    trailing: trailing.wrappedViewModel)
                         .createView(parentStyle: style)
 
-                    Text(sharedMarketViewModel.primaryDescription ?? "")
+                    Group {
+                        Text(sharedMarketViewModel.primaryDescription ?? "")
+                        Text(sharedMarketViewModel.secondaryDescription ?? "")
+                    }
                         .themeFont(fontSize: .medium)
-                        .padding(.vertical, 8)
-                        .padding(.horizontal, 16)
-                    Text(sharedMarketViewModel.secondaryDescription ?? "")
-                        .themeFont(fontSize: .medium)
-                        .themeColor(foreground: .textTertiary)
+                        .themeColor(foreground: .textSecondary)
                         .padding(.vertical, 8)
                         .padding(.horizontal, 16)
                 }


### PR DESCRIPTION
## Links
Linear Ticket: [TRCL-3055 : Market: differences in text color? make both secondary](https://linear.app/dydx/issue/TRCL-3055/market-differences-in-text-color-make-both-secondary)

also updates the PR template


<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/da84ad3c-6b0e-4946-9e17-5fae517116bb"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/3c2cda81-701b-4471-959c-bc05b9bacd48"> |

<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
