### PR TITLE
TRCL-3052 : After placing a trade, ensure user stays on the market they just traded on instead of being routed back to the overall markets page or portfolio page

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeStatus/dydxTradeStatusViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeStatus/dydxTradeStatusViewBuilder.swift
@@ -58,9 +58,7 @@ private class dydxTradeStatusViewPresenter: HostedViewPresenter<dydxTradeStatusV
     }()
 
     private let doneAction: (() -> Void) = {
-        Router.shared?.navigate(to: RoutingRequest(path: "/action/dismiss"), animated: true) { _, _ in
-            Router.shared?.navigate(to: RoutingRequest(path: "/action/dismiss"), animated: true, completion: nil)
-        }
+        Router.shared?.navigate(to: RoutingRequest(path: "/action/dismiss"), animated: true, completion: nil)
     }
 
     private lazy var tryAgainAction: (() -> Void) = { [weak self] in


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [TRCL-3052 : After placing a trade, ensure user stays on the market they just traded on instead of being routed back to the overall markets page or portfolio page](https://linear.app/dydx/issue/TRCL-3052/after-placing-a-trade-ensure-user-stays-on-the-market-they-just-traded)



<br/>

## Description / Intuition
from design:
> I think that the user should end up on the market info screen after they place a trade.
The reason being is that sometimes users have a few trades within a given strategy, and they're still able to see their position info from the market info screen.




<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/39f81772-5d32-4ed4-a8f9-a8a67f428ec9"> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/b966fba3-3388-4f41-8e5e-22a2f3c4b320"> |


<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
