### PR TITLE
Fix build: Pointing to the commit of the current cartera-ios repo.

### DIFF
--- a/dydxV4/dydxV4.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dydxV4/dydxV4.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "git@github.com:dydxprotocol/cartera-ios.git",
       "state" : {
         "branch" : "main",
-        "revision" : "4bd8aa80726ed12787f3db6767d67b076a0f9650"
+        "revision" : "610fffe691fb6fc2bf69230efd91d1887c050ae7"
       }
     },
     {


### PR DESCRIPTION
Hopefully this should fix the release build.
