### PR TITLE
TRCL-2841 : Trading Network current value not shown on Settings

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Settings/SettingsLandingViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Settings/SettingsLandingViewPresenter.swift
@@ -67,7 +67,6 @@ class SettingsLandingViewPresenter: SettingsViewPresenter {
               let localizerKey = SettingsStore.shared?.value(forKey: deepLink.settingsStoreKey) as? String
         else { return textViewModel }
 
-        let valueComponents = localizerKey.components(separatedBy: "-")
         if let displayTextKey = deepLink.localizerKeyLookup?[localizerKey] {
             textViewModel.text = DataLocalizer.shared?.localize(path: displayTextKey, params: nil)
         } else if let env = AbacusStateManager.shared.availableEnvironments.first(where: { $0.type == localizerKey }) {


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [TRCL-2841 : Trading Network current value not shown on Settings](https://linear.app/dydx/issue/TRCL-2841/trading-network-current-value-not-shown-on-settings)



<br/>

## Description / Intuition
issue is that we have json-configurable settings screens without support for current value look-ups. The solution was a best-effort look up a value/key in `availableEnvironments`


<br/>

## Before/After Screenshots or Videos

<img width="614" alt="Screenshot 2023-11-10 at 5 05 40 PM" src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/54dc410f-f538-4bf9-ac3b-77dbaf6e57cd" width=30%>

https://github.com/dydxprotocol/v4-native-ios/assets/149746839/77309665-f88d-46c9-a6d3-855564027a4f




<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
