### PR TITLE
TRCL-2863 : The section header on the Portfolio view should be sticky

### DIFF
--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/dydxPortfolioSectionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/dydxPortfolioSectionsView.swift
@@ -51,6 +51,7 @@ public class dydxPortfolioSectionsViewModel: PlatformViewModel {
                     }
                 }
                 .padding(.vertical, 16)
+                .themeColor(background: .layer2)
             )
         }
     }

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/dydxPortfolioView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/dydxPortfolioView.swift
@@ -147,26 +147,26 @@ public class dydxPortfolioViewModel: PlatformViewModel {
                     .animateHeight(height: self.expanded ? 460 : 332)
                     .animation(.easeIn(duration: 0.2), value: self.expanded)
 
-                    self.sections.createView(parentStyle: style)
-
-                    switch self.sectionSelection {
-                    case .trades:
-                        self.fills
-                            .createView(parentStyle: style)
-                    case .positions:
-                        self.positions
-                            .createView(parentStyle: style)
-                    case .orders:
-                        self.orders
-                            .createView(parentStyle: style)
-                    case .funding:
-                        self.funding
-                            .createView(parentStyle: style)
-                    case .transfers, .fees:
-                        PlatformView.nilView
+                    Section(header: self.sections.createView(parentStyle: style)) {
+                        switch self.sectionSelection {
+                        case .trades:
+                            self.fills
+                                .createView(parentStyle: style)
+                        case .positions:
+                            self.positions
+                                .createView(parentStyle: style)
+                        case .orders:
+                            self.orders
+                                .createView(parentStyle: style)
+                        case .funding:
+                            self.funding
+                                .createView(parentStyle: style)
+                        case .transfers, .fees:
+                            PlatformView.nilView
+                        }
+                        // add space to adjust for tab bar
+                        Spacer(minLength: 80)
                     }
-                    // add space to adjust for tab bar
-                    Spacer(minLength: 80)
                 }
             }
         )


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [TRCL-2863 : The section header on the Portfolio view should be sticky](https://linear.app/dydx/issue/TRCL-2863/the-section-header-on-the-portfolio-view-should-be-sticky)



<br/>

## Description / Intuition
moves the section selector into a `Section` view



<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/c7cb3d31-87d9-4ea0-80cb-e1920ca4fc37"> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/18077a3f-e16f-44e6-bfd3-50e363ec1e76"> |









<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
