### PR TITLE
Made layout consistent between orders and fills

### DIFF
--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFundingView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFundingView.swift
@@ -149,8 +149,12 @@ public class dydxPortfolioFundingViewModel: PlatformListViewModel {
 
     private let _placeholder = PlaceholderViewModel()
 
-    public init() {
-        super.init()
+    public init(items: [PlatformViewModel] = [], contentChanged: (() -> Void)? = nil) {
+        super.init(items: items,
+                   intraItemSeparator: true,
+                   firstListItemTopSeparator: true,
+                   lastListItemBottomSeparator: true,
+                   contentChanged: contentChanged)
         self.placeholder = _placeholder
         self.header = createHeader().wrappedViewModel
         self.width = UIScreen.main.bounds.width - 16
@@ -177,6 +181,7 @@ public class dydxPortfolioFundingViewModel: PlatformListViewModel {
             Text(DataLocalizer.localize(path: "APP.GENERAL.PRICE_FEE"))
         }
         .padding(.horizontal, 16)
+        .padding(.bottom, 16)
         .themeFont(fontSize: .small)
         .themeColor(foreground: .textTertiary)
     }

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioOrdersView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioOrdersView.swift
@@ -131,6 +131,7 @@ public class dydxPortfolioOrderItemViewModel: PlatformViewModel {
                 .frame(width: 42, height: 42)
             }
         }
+
     }
 
     private func createMain(parentStyle: ThemeStyle) -> some View {
@@ -188,8 +189,12 @@ public class dydxPortfolioOrdersViewModel: PlatformListViewModel {
 
     private let _placeholder = PlaceholderViewModel()
 
-    public init() {
-        super.init(intraItemSeparator: false)
+    public init(items: [PlatformViewModel] = [], contentChanged: (() -> Void)? = nil) {
+        super.init(items: items,
+                   intraItemSeparator: true,
+                   firstListItemTopSeparator: true,
+                   lastListItemBottomSeparator: true,
+                   contentChanged: contentChanged)
         self.placeholder = _placeholder
         self.header = createHeader().wrappedViewModel
         self.width = UIScreen.main.bounds.width - 16
@@ -211,6 +216,7 @@ public class dydxPortfolioOrdersViewModel: PlatformListViewModel {
             Text(DataLocalizer.localize(path: "APP.GENERAL.PRICE_TYPE"))
         }
         .padding(.horizontal, 16)
+        .padding(.bottom, 16)
         .themeFont(fontSize: .small)
         .themeColor(foreground: .textTertiary)
     }


### PR DESCRIPTION


<br/>

## Description / Intuition

Currently the padding and height are different..  This makes it consistent between orders and fills.


<br/>


https://github.com/dydxprotocol/v4-native-ios/assets/102453770/67b578da-fdf1-4df7-9883-a88b19f26453





<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
