### PR TITLE
TRCL-3293 : always show reduce only toggle, even if disabled

### DIFF
--- a/PlatformUI/PlatformUI/Components/Input/PlatformInput.swift
+++ b/PlatformUI/PlatformUI/Components/Input/PlatformInput.swift
@@ -502,6 +502,8 @@ open class PlatformPopoverOptionsInputViewModel: PlatformOptionsInputViewModel {
 
 open class PlatformBooleanInputViewModel: PlatformValueInputViewModel {
     
+    open var isEnabled: Bool = true
+    
     override open var value: String? {
         didSet {
             inputBinding.update()
@@ -528,6 +530,7 @@ open class PlatformBooleanInputViewModel: PlatformValueInputViewModel {
                     Spacer()
                     Toggle("", isOn: self.inputBinding)
                         .toggleStyle(SwitchToggleStyle(tint: ThemeColor.SemanticColor.colorPurple.color))
+                        .disabled(!self.isEnabled)
                 }
             )
         }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputEditPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputEditPresenter.swift
@@ -205,14 +205,15 @@ internal class dydxTradeInputEditViewPresenter: HostedViewPresenter<dydxTradeInp
             executionViewModel.value = tradeInput.execution
             visible.append(executionViewModel)
         }
-        if tradeInput.options?.needsPostOnly ?? false {
-            postOnlyViewModel.value = (tradeInput.postOnly == true) ? "true" : "false"
-            visible.append(postOnlyViewModel)
-        }
-        if tradeInput.options?.needsReduceOnly ?? false {
-            reduceOnlyViewModel.value = (tradeInput.reduceOnly == true) ? "true" : "false"
-            visible.append(reduceOnlyViewModel)
-        }
+
+        postOnlyViewModel.isEnabled = tradeInput.options?.needsPostOnly == true
+        postOnlyViewModel.value = (tradeInput.postOnly == true) ? "true" : "false"
+        visible.append(postOnlyViewModel)
+
+        reduceOnlyViewModel.isEnabled = tradeInput.options?.needsReduceOnly == true
+        reduceOnlyViewModel.value = (tradeInput.reduceOnly == true) ? "true" : "false"
+        visible.append(reduceOnlyViewModel)
+
         viewModel?.children = visible
     }
 }


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [TRCL-3293 : always show reduce only toggle, even if disabled](https://linear.app/dydx/issue/TRCL-3293/always-show-reduce-only-toggle-even-if-disabled)


<br/>

## Description / Intuition
from [this discussion](https://www.notion.so/Reduce-Only-IOC-FOK-Checkbox-3e0462c519db43f59d07ce71e0ab4d86?d=052643b0fe1c4dfb930c8fcc5160e1a8&pvs=4#0c03e382dfa945929825dc6f5d834ade)

design wants reduce only toggle to always be visible, disabled if not applicable/supported for the given trade configuration




<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/c51c3c5f-5235-46b7-b22f-4b4ef241cb5d"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/6e9ef179-d067-4e79-a0ca-b85791fe5d42"> |

<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
