### PR TITLE
Fix the issue of release build not getting the feature flag values

### DIFF
--- a/dydx/dydxFormatter/dydxFormatter/_Utils/dydxFeatureFlag.swift
+++ b/dydx/dydxFormatter/dydxFormatter/_Utils/dydxFeatureFlag.swift
@@ -19,7 +19,10 @@ public enum dydxBoolFeatureFlag: String, CaseIterable {
     private static let obj = NSObject()
 
     public var isEnabled: Bool {
-        Self.obj.parser.asBoolean(FeatureService.shared?.flag(feature: rawValue))?.boolValue ?? false
+        if FeatureService.shared == nil {
+            Console.shared.log("WARNING: FeatureService not yet set up.")
+        }
+        return Self.obj.parser.asBoolean(FeatureService.shared?.flag(feature: rawValue))?.boolValue ?? false
     }
 
     public static var enabledFlags: [String] {
@@ -35,7 +38,10 @@ public enum dydxStringFeatureFlag: String {
     private static let obj = NSObject()
 
     public var string: String? {
-        Self.obj.parser.asString(FeatureService.shared?.flag(feature: rawValue))
+        if FeatureService.shared == nil {
+            Console.shared.log("WARNING: FeatureService not yet set up.")
+        }
+        return Self.obj.parser.asString(FeatureService.shared?.flag(feature: rawValue))
     }
 }
 
@@ -45,6 +51,9 @@ public enum dydxNumberFeatureFlag: String {
     private static let obj = NSObject()
 
     public var number: NSNumber? {
-        Self.obj.parser.asNumber(FeatureService.shared?.flag(feature: rawValue))
+        if FeatureService.shared == nil {
+            Console.shared.log("WARNING: FeatureService not yet set up.")
+        }
+        return Self.obj.parser.asNumber(FeatureService.shared?.flag(feature: rawValue))
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxCarteraConfigWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxCarteraConfigWorker.swift
@@ -14,7 +14,9 @@ import Cartera
 
 final class dydxCarteraConfigWorker: BaseWorker {
 
-    override init() {
+    public override func start() {
+        super.start()
+
         let filePath = "configs/wallets.json"
         #if DEBUG
         let url: String? = nil
@@ -26,10 +28,6 @@ final class dydxCarteraConfigWorker: BaseWorker {
                 CarteraConfig.shared.registerWallets(configJsonData: walletJson)
             }
         }
-    }
-
-    public override func start() {
-        super.start()
 
         AbacusStateManager.shared.$currentEnvironment
             .removeDuplicates()

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Update/dydxUpdateViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Update/dydxUpdateViewPresenter.swift
@@ -42,7 +42,7 @@ private class dydxUpdateViewPresenter: HostedViewPresenter<dydxUpdateViewModel>,
 
         viewModel = dydxUpdateViewModel()
     }
-    
+
     override func start() {
         super.start()
 

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -14,7 +14,8 @@ import dydxFormatter
 public final class AbacusStateManager: NSObject {
     public static let shared = AbacusStateManager()
 
-    public let deploymentUri = {
+    public lazy var deploymentUri: String = {
+        // "lazy var" because FeatureService.shared needs be assigned first
         let url = dydxStringFeatureFlag.deployment_url.string ?? (CredientialConfig.shared.key(for: "webAppUrl"))!
         return url.last == "/" ? url : url + "/"
     }()

--- a/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxFAQView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxFAQView.swift
@@ -34,7 +34,7 @@ public class dydxFAQViewModel: PlatformViewModel {
                         .themeFont(fontType: .text, fontSize: .small)
                         .themeColor(foreground: .textSecondary)
                     Spacer(minLength: 16)
-                    //PlatformIconViewModel behaves weirdly here. When isExpanded is toggled, sometimes the icon hides entirely. Do not use.
+                    // PlatformIconViewModel behaves weirdly here. When isExpanded is toggled, sometimes the icon hides entirely. Do not use.
                     Image(self.isExpanded ? "icon_collapse" : "icon_expand", bundle: .dydxView)
                         .frame(width: hideShowImageDiameter, height: hideShowImageDiameter)
                         .padding(.all, paddingDim)


### PR DESCRIPTION
On Release build, the FeatureService.shared is assigned at a later time than the initialization of AbacusStateManager, which affects the value of `deploymentUri` sent to Abacus.  This PR makes necessary adjustment to ensure `deploymentUri` is expected.


### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
