### PR TITLE
TRCL-3370 Depth chart highlight, total cost was always $0

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketDepthChartViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketDepthChartViewPresenter.swift
@@ -259,9 +259,7 @@ class dydxMarketDepthChartViewPresenter: HostedViewPresenter<dydxMarketDepthChar
                     let stepSize = market.configs?.displayStepSizeDecimals?.intValue ?? 1
                     self?.viewModel?.hightlight?.price = dydxFormatter.shared.dollar(number: NSNumber(value: order.price), digits: tickSize)
                     self?.viewModel?.hightlight?.size = dydxFormatter.shared.localFormatted(number: NSNumber(value: order.size), digits: stepSize)
-                    if let depth = order.depth?.doubleValue {
-                        self?.viewModel?.hightlight?.cost = dydxFormatter.shared.dollar(number: NSNumber(value: depth), digits: tickSize)
-                    }
+                    self?.viewModel?.hightlight?.cost = dydxFormatter.shared.dollar(number: NSNumber(value: order.depthCost), digits: 2)    // This is total cost, always round to cents
                     self?.viewModel?.hightlight?.impact = dydxFormatter.shared.percent(number: self?.priceImpact(orderDataPoint: orderDataPoint), digits: 2)
 
                     switch orderDataPoint.side {


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: https://linear.app/dydx/issue/TRCL-3370/update-ios-app-depth-chart-selection-state-to-show-depth-total-cost

<br/>

## Description / Intuition
When highlight on the depth chart, we should show the accumulated total cost in dollar value.

<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src="https://github.com/dydxprotocol/v4-native-ios/assets/6576973/bc209589-c9b5-4c5a-a9c2-f5001d8062a1"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/6576973/3b7e4f71-2b65-49d7-8d96-ba80b4cd83ce"> |


<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
