### PR TITLE
TRCL-3495 Portfolio chart timeline has the selector defaults to 7d, but is disp…

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioChartViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioChartViewPresenter.swift
@@ -68,7 +68,7 @@ class dydxPortfolioChartViewPresenter: HostedViewPresenter<dydxPortfolioChartVie
         let defaultResolutionIndex = 1
         viewModel?.resolutionTitles = Resolution.allResolutions.map(\.text)
         viewModel?.resolutionIndex = defaultResolutionIndex
-        viewModel?.pnlLabel = DataLocalizer.localize(path: "APP.GENERAL.PROFIT_AND_LOSS_WITH_DURATION", params: ["PERIOD": Resolution.allResolutions[3].text])
+        viewModel?.pnlLabel = DataLocalizer.localize(path: "APP.GENERAL.PROFIT_AND_LOSS_WITH_DURATION", params: ["PERIOD": Resolution.allResolutions[defaultResolutionIndex].text])
         AbacusStateManager.shared.setHistoricalPNLPeriod(period: Resolution.allResolutions[defaultResolutionIndex].key)
 
         viewModel?.onResolutionChanged = { index in


### PR DESCRIPTION
…laying 90d content


## Description / Intuition

![Simulator Screenshot - iPhone 14 Pro - 2024-01-24 at 01 06 33](https://github.com/dydxprotocol/v4-native-ios/assets/102453770/3fb19506-20f0-4b5f-925d-dfa6fb912ecb)




<br/>

## Before/After Screenshots or Videos






<br/>

### Type of Change
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
