### PR TITLE
TRCL-3515 : update dydx trading v4 scheme

### DIFF
--- a/dydxV4/dydxV4/AppDelegate.swift
+++ b/dydxV4/dydxV4/AppDelegate.swift
@@ -138,7 +138,7 @@ class AppDelegate: CommonAppDelegate {
     override func router() -> RouterProtocol? {
         let routingFile = "routing_swiftui.json"
 
-        let scheme = Bundle.main.scheme ?? "dydxv4"
+        let scheme = Bundle.main.scheme ?? "dydx_t_v4"
         if let file = Bundle.dydxPresenters.path(forResource: routingFile, ofType: ""),
            let jsonString = try? String(contentsOfFile: file).replacingOccurrences(of: "{APP_SCHEME}", with: scheme) {
             let router = MappedUIKitAppRouter(jsonString: jsonString)

--- a/dydxV4/dydxV4/Info.plist
+++ b/dydxV4/dydxV4/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>dYdX V4</string>
+	<string>dYdX_t V4</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -29,7 +29,7 @@
 			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>{APP_SCHEME}</string>
+				<string>dydx_t_v4</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [TRCL-3515 : \[Jan23-2024 iOS Testing\] update dydx trading v4 scheme](https://linear.app/dydx/issue/TRCL-3515/[jan23-2024-ios-testing]-update-dydx-trading-v4-scheme)

## Description:
Now scheme will be `dydx_t_v4` and app name will be `dydx_t v4` where the `t` stands for trading

<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
