### PR TITLE
TRCL-3504 : "-$0" formatting

### DIFF
--- a/dydx/dydxFormatter/dydxFormatter.xcodeproj/xcshareddata/xcschemes/dydxFormatterTests.xcscheme
+++ b/dydx/dydxFormatter/dydxFormatter.xcodeproj/xcshareddata/xcschemes/dydxFormatterTests.xcscheme
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1520"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02841E3229AD6E5500C0E7CC"
+               BuildableName = "dydxFormatterTests.xctest"
+               BlueprintName = "dydxFormatterTests"
+               ReferencedContainer = "container:dydxFormatter.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -18,12 +18,48 @@ final class dydxFormatterTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func testDollarFormatting() throws {
+        var number: Double = 1
+        var digits = 2
+        var formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        var expected = "$1.00"
+        XCTAssertEqual(formatted, expected)
+        
+        number = -0.001
+        digits = 0
+        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        expected = "$0"
+        XCTAssertEqual(formatted, expected)
+        
+        number = -0.001
+        digits = 2
+        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        expected = "$0.00"
+        XCTAssertEqual(formatted, expected)
+        
+        number = -0.001
+        digits = 3
+        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        expected = "-$0.001"
+        XCTAssertEqual(formatted, expected)
+        
+        number = 0.001
+        digits = 2
+        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        expected = "$0.00"
+        XCTAssertEqual(formatted, expected)
+        
+        number = -0.005
+        digits = 2
+        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        expected = "$0.00"
+        XCTAssertEqual(formatted, expected)
+        
+        number = -0.0051
+        digits = 2
+        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
+        expected = "-$0.01"
+        XCTAssertEqual(formatted, expected)
     }
 
     func testPerformanceExample() throws {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/NewsAlerts/AlertProvider/Providers/dydxTransferAlertsProvider.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/NewsAlerts/AlertProvider/Providers/dydxTransferAlertsProvider.swift
@@ -42,7 +42,7 @@ class dydxTransferAlertsProvider: dydxBaseAlertsProvider, dydxCustomAlertsProvid
     }
 
     private func createTransferStatusAlertItem(transfer: dydxTransferInstance) -> PlatformViewModel? {
-        let usdcSize = dydxFormatter.shared.dollar(number: transfer.usdcSize, digits: 2)
+        let usdcSize = dydxFormatter.shared.dollar(number: transfer.usdcSize)
         let size = dydxFormatter.shared.raw(number: Parser.standard.asNumber(transfer.size), digits: 2)
 
         let title: String?

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferStatus/dydxTransferStatusViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferStatus/dydxTransferStatusViewBuilder.swift
@@ -144,7 +144,7 @@ private class dydxTransferStatusViewPresenter: HostedViewPresenter<dydxTransferS
         let size = parser.asNumber(transfer.usdcSize ?? transferInput?.size?.usdcSize)?.doubleValue
         if transferInput != nil {
             viewModel?.title = DataLocalizer.localize(path: "APP.V4_DEPOSIT.IN_PROGRESS_TITLE")
-            let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size, digits: 2) ?? ""]
+            let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size) ?? ""]
             viewModel?.text = DataLocalizer.localize(path: "APP.V4_DEPOSIT.IN_PROGRESS_TEXT", params: params)
         } else {
             viewModel?.title = DataLocalizer.localize(path: "APP.V4_DEPOSIT.CHECK_STATUS_TITLE")
@@ -173,7 +173,7 @@ private class dydxTransferStatusViewPresenter: HostedViewPresenter<dydxTransferS
                 deleteTransferInstance(transactionHash: transactionHash)
             } else {
                 let size = parser.asNumber(transfer.usdcSize ?? transferInput?.size?.usdcSize)?.doubleValue
-                let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size, digits: 2) ?? ""]
+                let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size) ?? ""]
                 viewModel?.title = DataLocalizer.localize(path: "APP.V4_DEPOSIT.IN_PROGRESS_TITLE")
                 viewModel?.text = DataLocalizer.localize(path: "APP.V4_DEPOSIT.IN_PROGRESS_TEXT", params: params) + " " + status.statusText
 
@@ -204,7 +204,7 @@ private class dydxTransferStatusViewPresenter: HostedViewPresenter<dydxTransferS
         let size = parser.asNumber(transfer.usdcSize ?? transferInput?.size?.usdcSize)?.doubleValue
         if transferInput != nil {
             viewModel?.title = DataLocalizer.localize(path: "APP.V4_WITHDRAWAL.IN_PROGRESS_TITLE")
-            let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size, digits: 2) ?? ""]
+            let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size) ?? ""]
             viewModel?.text = DataLocalizer.localize(path: "APP.V4_WITHDRAWAL.IN_PROGRESS_TEXT", params: params)
         } else {
             viewModel?.title = DataLocalizer.localize(path: "APP.V4_WITHDRAWAL.CHECK_STATUS_TITLE")
@@ -234,7 +234,7 @@ private class dydxTransferStatusViewPresenter: HostedViewPresenter<dydxTransferS
                 deleteTransferInstance(transactionHash: transactionHash)
             } else {
                 let size = parser.asNumber(transfer.usdcSize ?? transferInput?.size?.usdcSize)?.doubleValue
-                let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size, digits: 2) ?? ""]
+                let params = ["AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: size) ?? ""]
                 viewModel?.title = DataLocalizer.localize(path: "APP.V4_WITHDRAWAL.IN_PROGRESS_TITLE")
                 viewModel?.text = DataLocalizer.localize(path: "APP.V4_WITHDRAWAL.IN_PROGRESS_TEXT", params: params) + " " + status.statusText
 
@@ -268,7 +268,7 @@ private class dydxTransferStatusViewPresenter: HostedViewPresenter<dydxTransferS
         let params: [String: String]
         if let usdcSize = transfer.usdcSize {
             params = [
-                "AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: usdcSize, digits: 2) ?? "",
+                "AMOUNT_ELEMENT": dydxFormatter.shared.dollar(number: usdcSize) ?? "",
                 "TOKEN": dydxTokenConstants.usdcTokenName
             ]
         } else if let size = transfer.size {


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [TRCL-3504 : "-$0" formatting](https://linear.app/dydx/issue/TRCL-3504/[jan23-2024-ios-testing]-dollar0-formatting)



<br/>

## Description / Intuition
- adds dydxformatter testing scheme
- replaces redundant `digits: 2`
- adds tests
- fixes formatting negative, near 0 values to "-$0.00"

<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/71f3775b-7871-495b-9f8d-880a60606db3"> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/72504192-2fb5-4996-9507-4d3be7ed9e67"> |



<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
