### PR TITLE
update license year, update v4-client

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2023 dYdX Trading Inc.
+Copyright (C) 2024 dYdX Trading Inc.
 
 Subject to your compliance with applicable law and the v4 Terms of Use, available at dydx.exchange/legal, you are granted the right to use the Program or Licensed Work (defined below) under the terms of the GNU Affero General Public License as set forth below; provided, however, that if you violate any such applicable law in your use of the Program or Licensed Work, all of your rights and licenses to use (including any rights to reproduce, distribute, install or modify) the Program or Licensed Work will automatically and immediately terminate.
 
@@ -799,4 +799,4 @@ copy of the Program in return for a fee.
 
 
 For more information about this software, see https://dydx.exchange. 
- Copyright (C) 2023 dYdX Trading Inc.
+ Copyright (C) 2024 dYdX Trading Inc.

--- a/scripts/update_client_api.sh
+++ b/scripts/update_client_api.sh
@@ -21,7 +21,7 @@ cleanup() {
 trap cleanup EXIT
 
 # Cloning into the temporary directory and navigating there
-git clone --branch ios git@github.com:dydxprotocol/v4-clients.git "$TMP_DIR/v4-clients"
+git clone git@github.com:dydxprotocol/v4-clients.git "$TMP_DIR/v4-clients"
 cd "$TMP_DIR/v4-clients/v4-client-js"
 
 # If cloning fails, exit the script


### PR DESCRIPTION
## Description / Intuition
- license year 2023 -> 2024
- update v4-client from `main` instead of `ios` branch