### PR TITLE
remove setting default env

### DIFF
--- a/dydxV4/dydxV4/_Settings/dydxSettingsStore.swift
+++ b/dydxV4/dydxV4/_Settings/dydxSettingsStore.swift
@@ -14,7 +14,6 @@ class dydxDebugSettingsStore: DebugSettingsStore {
     static let defaultValues: [String: String?] = [
         "language": DataLocalizer.shared?.language,
         "v4_theme": dydxThemeType.dark.rawValue,
-        "AbacusStateManager.EnvState": "dydxprotocol-testnet",
         // whether green or red is the positive direction
         "direction_color_preference": "green_is_up"
     ]


### PR DESCRIPTION
## Description / Intuition
Abacus uses the `env.json` file to determine the default environment. Default environment should not be hardcoded elsewhere, otherwise the `env.json`'s `deplyment.default` has no effect.

After this change, the `env.json`'s default values are observed