### PR TITLE
MOB-95 : Improve draft hide/show animation

### DIFF
--- a/Utilities/Utilities/_Notification/NotificationService.swift
+++ b/Utilities/Utilities/_Notification/NotificationService.swift
@@ -43,7 +43,7 @@ public class NotificationConfiguration: NSObject {
     @objc var authorization: NotificationPermission? { get set }
     @objc var configuration: NotificationConfiguration? { get set }
     @objc var permission: EPrivacyPermission { get set }
-    @objc var delegate: NotificationHandlerDelegate? { get set }
+    @objc weak var delegate: NotificationHandlerDelegate? { get set }
     
     func request()
     func present(message: [AnyHashable: Any])
@@ -60,7 +60,7 @@ public class NotificationService: NSObject {
 
 @objc open class NotificationHandler: NSObject, NotificationHandlerProtocol {
   
-    public var delegate: NotificationHandlerDelegate?
+    public weak var delegate: NotificationHandlerDelegate?
     
     @objc open dynamic var authorization: NotificationPermission? {
         didSet {

--- a/dydx/dydxViews/dydxViews/_v4/Receipt/dydxReceiptView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Receipt/dydxReceiptView.swift
@@ -15,11 +15,7 @@ public class dydxReceiptViewModel: PlatformViewModel {
             updateCollapsed()
         }
     }
-    @Published public var maxCollapsedItems: Int = 4 {
-        didSet {
-            updateCollapsed()
-        }
-    }
+    public let maxCollapsedItems: Int = 4
 
     @Published private var collapsed: Bool = true
 
@@ -43,13 +39,6 @@ public class dydxReceiptViewModel: PlatformViewModel {
             let children = self.children ?? []
             let items = self.collapsed ? Array(children.prefix(self.maxCollapsedItems - 1)) : children
 
-            let height: Double?
-            if children.count <= self.maxCollapsedItems || self.collapsed {
-                height = 132
-            } else {
-                height = nil
-            }
-
             let content = VStack(alignment: .leading) {
                 ForEach(items, id: \.self.id) { child in
                     child.createView(parentStyle: style)
@@ -58,23 +47,12 @@ public class dydxReceiptViewModel: PlatformViewModel {
                 Spacer().frame(maxHeight: 16)
                 if children.count > self.maxCollapsedItems {
                     self.createCollapseButton(parentStyle: style)
-                } else {
-                    Spacer()
                 }
             }
-
-            if let height = height {
-                return AnyView(
-                    content
-                        .frame(height: height)
-                        .animation(.default, value: UUID())
-                )
-            } else {
-                return AnyView(
-                    content
-                        .animation(.default, value: UUID())
-                )
-            }
+            return AnyView(
+                content
+                    .animation(.default, value: UUID())
+            )
         }
     }
 
@@ -94,18 +72,18 @@ public class dydxReceiptViewModel: PlatformViewModel {
             .padding(.vertical, -4)
 
         return Button(action: { [weak self] in
-            withAnimation(Animation.linear(duration: 0.1)) {
+            withAnimation {
                 self?.collapsed.toggle()
             }
         }) {
             content
-         }
-         .buttonStyle(BorderlessButtonStyle())
-         .frame(maxWidth: .infinity)
-         .padding()
-         .themeColor(background: .layer3)
-         .borderAndClip(style: .cornerRadius(12), borderColor: .borderDefault, lineWidth: 1)
-         .padding(.horizontal, -8)
+        }
+        .buttonStyle(BorderlessButtonStyle())
+        .frame(maxWidth: .infinity)
+        .padding()
+        .themeColor(background: .layer3)
+        .borderAndClip(style: .cornerRadius(12), borderColor: .borderDefault, lineWidth: 1)
+        .padding(.horizontal, -8)
     }
 
     private func updateCollapsed() {

--- a/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/Components/Orderbook/dydxOrderbookSideView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/Components/Orderbook/dydxOrderbookSideView.swift
@@ -75,7 +75,7 @@ public class dydxOrderbookSideViewModel: PlatformViewModel, Equatable {
     @Published public var lines = [dydxOrderbookLine]()
     @Published public var maxDepth: Double = 0.0
     @Published public var displayStyle: DisplayStyle = .topDown
-    var delegate: dydxOrderbookSideDelegate?
+    weak var delegate: dydxOrderbookSideDelegate?
 
     override public func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformView {
         PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] _ in

--- a/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/dydxTradeInputView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/dydxTradeInputView.swift
@@ -97,7 +97,6 @@ public class dydxTradeInputViewModel: PlatformViewModel {
                         self.editViewModel?.createView(parentStyle: style)
                             .frame(width: self.isOrderbookCollapsed ? fullWidth: editViewWidth)
                     }
-                    .frame(minHeight: 0, maxHeight: .infinity)
 
                     VStack(spacing: -8) {
                         if self.isShowingValidation {


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-95 : \[Jan23-2024 iOS Testing\] Improve draft hide/show animation](https://linear.app/dydx/issue/MOB-95/[jan23-2024-ios-testing]-improve-draft-hideshow-animation)



<br/>

## Description / Intuition
- smoothed animation of hiding/showing receipt details
- improved height calculation for receipt view
- `weak var delegate` [followup](https://github.com/dydxprotocol/v4-native-ios/pull/83#discussion_r1478895834)




<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/a3ba0540-f9a4-4c67-b63b-cb9bff37c20b"> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/36620c47-847b-42bb-b510-a8f9d074aff9"> |



<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
