### PR TITLE
MOB-94 : match signed number formatting to web

### DIFF
--- a/ParticlesKit/ParticlesKit/_Interactor/_Lines/ObjectLinesInteractor.swift
+++ b/ParticlesKit/ParticlesKit/_Interactor/_Lines/ObjectLinesInteractor.swift
@@ -22,7 +22,7 @@ import Utilities
     private lazy var dollarFormatter: ValueFormatterProtocol = DollarValueFormatter()
     private lazy var leverageFormatter: ValueFormatterProtocol = LeverageValueFormatter()
     private lazy var amountFormatter: ValueFormatterProtocol = AmountValueFormatter()
-    private lazy var percentFormatter: ValueFormatterProtocol = PercentValueFormatter()
+    private lazy var decimalFormatter: ValueFormatterProtocol = PercentValueFormatter()
 
     @objc open dynamic var fields: [String: ObjectLineInteractor]? {
         didSet {
@@ -118,7 +118,7 @@ import Utilities
             return dollarFormatter
 
         case "percent":
-            return percentFormatter
+            return decimalFormatter
 
         case "leverage":
             return leverageFormatter

--- a/ParticlesKit/ParticlesKit/_Interactor/_Lines/ObjectLinesInteractor.swift
+++ b/ParticlesKit/ParticlesKit/_Interactor/_Lines/ObjectLinesInteractor.swift
@@ -22,7 +22,7 @@ import Utilities
     private lazy var dollarFormatter: ValueFormatterProtocol = DollarValueFormatter()
     private lazy var leverageFormatter: ValueFormatterProtocol = LeverageValueFormatter()
     private lazy var amountFormatter: ValueFormatterProtocol = AmountValueFormatter()
-    private lazy var decimalFormatter: ValueFormatterProtocol = PercentValueFormatter()
+    private lazy var percentFormatter: ValueFormatterProtocol = PercentValueFormatter()
 
     @objc open dynamic var fields: [String: ObjectLineInteractor]? {
         didSet {
@@ -118,7 +118,7 @@ import Utilities
             return dollarFormatter
 
         case "percent":
-            return decimalFormatter
+            return percentFormatter
 
         case "leverage":
             return leverageFormatter

--- a/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
+++ b/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
@@ -7,12 +7,18 @@
 //
 
 import SwiftUI
+import dydxFormatter
 
 public class SignedAmountViewModel: PlatformViewModel, Hashable {
     public enum ColoringOption {
         case signOnly
         case textOnly
         case allText
+    }
+    
+    public enum DisplayType {
+        case dollar
+        case percent
     }
     
     @Published public var text: String?
@@ -28,6 +34,35 @@ public class SignedAmountViewModel: PlatformViewModel, Hashable {
         self.positiveTextStyleKey = positiveTextStyleKey
         self.negativeTextStyleKey = negativeTextStyleKey
     }
+    
+    public convenience init(amount: Double?, displayType: DisplayType, coloringOption: ColoringOption, positiveTextStyleKey: String, negativeTextStyleKey: String, shouldDisplaySignForPositiveNumbers: Bool = false) {
+        let formattedZero: String
+        let formattedText: String
+        let sign: PlatformUISign
+        switch displayType {
+        case .dollar:
+            formattedText = dydxFormatter.shared.dollarVolume(number: amount, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+            formattedZero = dydxFormatter.shared.dollarVolume(number: 0.0, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+        case .percent:
+            let digits = 2
+            formattedText = dydxFormatter.shared.percent(number: amount, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+            formattedZero = dydxFormatter.shared.percent(number: 0.0, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+        }
+        if formattedText == formattedZero {
+            sign = .none
+        } else if (amount ?? 0) > 0 {
+            sign = .plus
+        } else {
+            sign = .minus
+        }
+        self.init(text: formattedText,
+                  sign: sign,
+                  coloringOption: coloringOption,
+                  positiveTextStyleKey: positiveTextStyleKey,
+                  negativeTextStyleKey: negativeTextStyleKey)
+    }
+    
+    
     
     public static func == (lhs: SignedAmountViewModel, rhs: SignedAmountViewModel) -> Bool {
         lhs.text == rhs.text &&

--- a/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
+++ b/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
@@ -7,7 +7,6 @@
 //
 
 import SwiftUI
-import dydxFormatter
 
 public class SignedAmountViewModel: PlatformViewModel, Hashable {
     public enum ColoringOption {
@@ -34,35 +33,6 @@ public class SignedAmountViewModel: PlatformViewModel, Hashable {
         self.positiveTextStyleKey = positiveTextStyleKey
         self.negativeTextStyleKey = negativeTextStyleKey
     }
-    
-    public convenience init(amount: Double?, displayType: DisplayType, coloringOption: ColoringOption, positiveTextStyleKey: String, negativeTextStyleKey: String, shouldDisplaySignForPositiveNumbers: Bool = false) {
-        let formattedZero: String
-        let formattedText: String
-        let sign: PlatformUISign
-        switch displayType {
-        case .dollar:
-            formattedText = dydxFormatter.shared.dollarVolume(number: amount, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
-            formattedZero = dydxFormatter.shared.dollarVolume(number: 0.0, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
-        case .percent:
-            let digits = 2
-            formattedText = dydxFormatter.shared.percent(number: amount, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
-            formattedZero = dydxFormatter.shared.percent(number: 0.0, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
-        }
-        // special logic for when a value like -0.001 would render as "-$0.00" instead of "$0.00"
-        if formattedText == formattedZero {
-            sign = .none
-        } else if (amount ?? 0) > 0 {
-            sign = .plus
-        } else {
-            sign = .minus
-        }
-        self.init(text: formattedText,
-                  sign: sign,
-                  coloringOption: coloringOption,
-                  positiveTextStyleKey: positiveTextStyleKey,
-                  negativeTextStyleKey: negativeTextStyleKey)
-    }
-    
     
     
     public static func == (lhs: SignedAmountViewModel, rhs: SignedAmountViewModel) -> Bool {

--- a/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
+++ b/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
@@ -7,12 +7,18 @@
 //
 
 import SwiftUI
+import dydxFormatter
 
 public class SignedAmountViewModel: PlatformViewModel, Hashable {
     public enum ColoringOption {
         case signOnly
         case textOnly
         case allText
+    }
+    
+    public enum DisplayType {
+        case dollar
+        case percent
     }
     
     @Published public var text: String?
@@ -28,6 +34,36 @@ public class SignedAmountViewModel: PlatformViewModel, Hashable {
         self.positiveTextStyleKey = positiveTextStyleKey
         self.negativeTextStyleKey = negativeTextStyleKey
     }
+    
+    public convenience init(amount: Double?, displayType: DisplayType, coloringOption: ColoringOption, positiveTextStyleKey: String, negativeTextStyleKey: String, shouldDisplaySignForPositiveNumbers: Bool = false) {
+        let formattedZero: String
+        let formattedText: String
+        let sign: PlatformUISign
+        switch displayType {
+        case .dollar:
+            formattedText = dydxFormatter.shared.dollarVolume(number: amount, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+            formattedZero = dydxFormatter.shared.dollarVolume(number: 0.0, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+        case .percent:
+            let digits = 2
+            formattedText = dydxFormatter.shared.percent(number: amount, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+            formattedZero = dydxFormatter.shared.percent(number: 0.0, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers) ?? ""
+        }
+        // special logic for when a value like -0.001 would render as "-$0.00" instead of "$0.00"
+        if formattedText == formattedZero {
+            sign = .none
+        } else if (amount ?? 0) > 0 {
+            sign = .plus
+        } else {
+            sign = .minus
+        }
+        self.init(text: formattedText,
+                  sign: sign,
+                  coloringOption: coloringOption,
+                  positiveTextStyleKey: positiveTextStyleKey,
+                  negativeTextStyleKey: negativeTextStyleKey)
+    }
+    
+    
     
     public static func == (lhs: SignedAmountViewModel, rhs: SignedAmountViewModel) -> Bool {
         lhs.text == rhs.text &&

--- a/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
+++ b/PlatformUI/PlatformUI/Components/Labels/SignedAmount.swift
@@ -21,7 +21,7 @@ public class SignedAmountViewModel: PlatformViewModel, Hashable {
     @Published public var positiveTextStyleKey: String
     @Published public var negativeTextStyleKey: String
 
-    public init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption = .signOnly, positiveTextStyleKey: String, negativeTextStyleKey: String) {
+    public init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption, positiveTextStyleKey: String, negativeTextStyleKey: String) {
         self.text = text
         self.sign = sign
         self.coloringOption = coloringOption
@@ -41,7 +41,7 @@ public class SignedAmountViewModel: PlatformViewModel, Hashable {
         hasher.combine(coloringOption)
     }
     
-    public static var previewValue = SignedAmountViewModel(text: "2.02", sign: .plus, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus")
+    public static var previewValue = SignedAmountViewModel(text: "2.02", sign: .plus, coloringOption: .allText, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus")
 
     public override func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformView {
         PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] style  in
@@ -98,10 +98,10 @@ struct SignedAmount_Previews: PreviewProvider {
 
     static var previews: some View {
         Group {
-            SignedAmountViewModel(text: "$2.00", sign: .plus, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus").createView()
+            SignedAmountViewModel(text: "$2.00", sign: .plus, coloringOption: .allText, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus").createView()
                 .previewLayout(.sizeThatFits)
             
-            SignedAmountViewModel(text: "$2.00", sign: .minus, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus").createView()
+            SignedAmountViewModel(text: "$2.00", sign: .minus, coloringOption: .allText, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus").createView()
                 .previewLayout(.sizeThatFits)
             
             SignedAmountViewModel(text: "$2.00", sign: .plus, coloringOption: .allText, positiveTextStyleKey: "signed-plus", negativeTextStyleKey: "signed-minus").createView()

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -234,17 +234,33 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
         return nil
     }
 
-    public func dollarVolume(number: Double?, digits: Int = 2) -> String? {
+    ///  formats the number as "$" or "-$" of "+$" prefixed
+    /// - Parameters:
+    ///   - number: the number to format
+    ///   - digits: after-decimal precision
+    ///   - shouldDisplaySignForPositiveNumbers: whether to include "+" in the prefix for positive numbers
+    /// - Returns: the number formatted as a dollar amount
+    public func dollarVolume(number: Double?, digits: Int = 2, shouldDisplaySignForPositiveNumbers: Bool = false) -> String? {
         if let number = number {
             return dollarVolume(number: NSNumber(value: number), digits: digits)
         }
         return nil
     }
 
-    public func dollarVolume(number: NSNumber?, digits: Int = 2) -> String? {
-        if let number = number, let formatted = condensed(number: number.abs(), digits: digits) {
-            if number.doubleValue >= 0.0 {
+    ///  formats the number as "$" or "-$" of "+$" prefixed
+    /// - Parameters:
+    ///   - number: the number to format
+    ///   - digits: after-decimal precision
+    ///   - shouldDisplaySignForPositiveNumbers: whether to include "+" in the prefix for positive numbers
+    /// - Returns: the number formatted as a dollar amount
+    public func dollarVolume(number: NSNumber?, digits: Int = 2, shouldDisplaySignForPositiveNumbers: Bool = false) -> String? {
+        if let number = number,
+            let formatted = condensed(number: number.abs(), digits: digits),
+            let formattedZero = condensed(number: number.abs(), digits: digits) {
+            if formattedZero == formatted {
                 return "$\(formatted)"
+            } else if number.doubleValue >= 0.0 {
+                return "\(shouldDisplaySignForPositiveNumbers ? "+" : "")$\(formatted)"
             } else {
                 return "-$\(formatted)"
             }
@@ -434,21 +450,28 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
         }
     }
 
-    public func percent(number: Double?, digits: Int, minDigits: Int? = nil) -> String? {
+    public func percent(number: Double?, digits: Int, minDigits: Int? = nil, shouldDisplayPlusSignForPositiveNumbers: Bool = false) -> String? {
         if let number = number {
-            return percent(number: NSNumber(value: number), digits: digits, minDigits: minDigits)
+            return percent(number: NSNumber(value: number), digits: digits, minDigits: minDigits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplayPlusSignForPositiveNumbers)
         }
         return nil
     }
 
-    public func percent(number: NSNumber?, digits: Int, minDigits: Int? = nil) -> String? {
+    public func percent(number: NSNumber?, digits: Int, minDigits: Int? = nil, shouldDisplayPlusSignForPositiveNumbers: Bool = false) -> String? {
         if let number = number {
             if number.doubleValue.isFinite {
                 let percent = NSNumber(value: number.doubleValue * 100.0)
                 percentFormatter.minimumFractionDigits = minDigits ?? digits
                 percentFormatter.maximumFractionDigits = digits
-                if let formatted = percentFormatter.string(from: percent) {
-                    return "\(formatted)%"
+                if let formatted = percentFormatter.string(from: percent),
+                   let formattedZero = percentFormatter.string(from: 0) {
+                    if formattedZero == formatted {
+                        return "\(formatted)%"
+                    } else if number.doubleValue >= 0.0 {
+                        return "\(shouldDisplayPlusSignForPositiveNumbers ? "+" : "")\(formatted)%"
+                    } else {
+                        return nil
+                    }
                 } else {
                     return nil
                 }

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -45,7 +45,6 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
 
     private var percentFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
-        formatter.roundingMode = .up
         formatter.numberStyle = .decimal
         formatter.minimumFractionDigits = 2
         formatter.maximumFractionDigits = 2
@@ -242,7 +241,7 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
     /// - Returns: the number formatted as a dollar amount
     public func dollarVolume(number: Double?, digits: Int = 2, shouldDisplaySignForPositiveNumbers: Bool = false) -> String? {
         if let number = number {
-            return dollarVolume(number: NSNumber(value: number), digits: digits)
+            return dollarVolume(number: NSNumber(value: number), digits: digits, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
         }
         return nil
     }
@@ -256,7 +255,7 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
     public func dollarVolume(number: NSNumber?, digits: Int = 2, shouldDisplaySignForPositiveNumbers: Bool = false) -> String? {
         if let number = number,
             let formatted = condensed(number: number.abs(), digits: digits),
-            let formattedZero = condensed(number: number.abs(), digits: digits) {
+           let formattedZero = condensed(number: 0.0, digits: digits) {
             if formattedZero == formatted {
                 return "$\(formatted)"
             } else if number.doubleValue >= 0.0 {
@@ -463,12 +462,14 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
                 let percent = NSNumber(value: number.doubleValue * 100.0)
                 percentFormatter.minimumFractionDigits = minDigits ?? digits
                 percentFormatter.maximumFractionDigits = digits
-                if let formatted = percentFormatter.string(from: percent),
+                if let formatted = percentFormatter.string(from: percent.abs()),
                    let formattedZero = percentFormatter.string(from: 0) {
                     if formattedZero == formatted {
                         return "\(formatted)%"
                     } else if number.doubleValue >= 0.0 {
                         return "\(shouldDisplayPlusSignForPositiveNumbers ? "+" : "")\(formatted)%"
+                    } else if number.doubleValue < 0.0 {
+                        return "-\(formatted)%"
                     } else {
                         return nil
                     }

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -19,47 +19,82 @@ final class dydxFormatterTests: XCTestCase {
     }
 
     func testDollarFormatting() throws {
-        var number: Double = 1
-        var digits = 2
-        var formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        var expected = "$1.00"
-        XCTAssertEqual(formatted, expected)
-
-        number = -0.001
-        digits = 0
-        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        expected = "$0"
-        XCTAssertEqual(formatted, expected)
-
-        number = -0.001
-        digits = 2
-        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        expected = "$0.00"
-        XCTAssertEqual(formatted, expected)
-
-        number = -0.001
-        digits = 3
-        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        expected = "-$0.001"
-        XCTAssertEqual(formatted, expected)
-
-        number = 0.001
-        digits = 2
-        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        expected = "$0.00"
-        XCTAssertEqual(formatted, expected)
-
-        number = -0.005
-        digits = 2
-        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        expected = "$0.00"
-        XCTAssertEqual(formatted, expected)
-
-        number = -0.0051
-        digits = 2
-        formatted = dydxFormatter.shared.dollar(number: number, digits: digits)
-        expected = "-$0.01"
-        XCTAssertEqual(formatted, expected)
+        struct TestCase {
+            let number: Double
+            let digits: Int
+            let expected: String
+        }
+        
+        let testCases: [TestCase] = [
+            .init(number: 1,        digits: 2, expected: "$1.00"),
+            .init(number: -0.001,   digits: 0, expected: "$0"),
+            .init(number: -0.001,   digits: 3, expected: "-$0.001"),
+            .init(number: -0.001,   digits: 2, expected: "$0.00"),
+            .init(number: 0.001,    digits: 2, expected: "$0.00"),
+            .init(number: -0.005,   digits: 2, expected: "$0.00"),
+            .init(number: -0.0051,  digits: 2, expected: "-$0.01")
+        ]
+        
+        for testCase in testCases {
+            let formatted = dydxFormatter.shared.dollar(number: testCase.number, digits: testCase.digits)
+            XCTAssertEqual(formatted, testCase.expected)
+        }
+    }
+    
+    func testDollarVolumeFormatting() throws {
+        struct TestCase {
+            let number: Double
+            let digits: Int
+            let shouldDisplaySignForPositiveNumbers: Bool
+            let expected: String
+        }
+        
+        let testCases: [TestCase] = [
+            .init(number: 1,        digits: 2, shouldDisplaySignForPositiveNumbers: false, expected: "$1.00"),
+            .init(number: -0.001,   digits: 0, shouldDisplaySignForPositiveNumbers: false, expected: "$0"),
+            .init(number: -0.001,   digits: 3, shouldDisplaySignForPositiveNumbers: false, expected: "-$0.001"),
+            .init(number: -0.001,   digits: 2, shouldDisplaySignForPositiveNumbers: false, expected: "$0.00"),
+            .init(number: 0.001,    digits: 2, shouldDisplaySignForPositiveNumbers: false, expected: "$0.00"),
+            .init(number: -0.005,   digits: 2, shouldDisplaySignForPositiveNumbers: false, expected: "$0.00"),
+            .init(number: -0.0051,  digits: 2, shouldDisplaySignForPositiveNumbers: false, expected: "-$0.01"),
+            .init(number: 1,  digits: 2, shouldDisplaySignForPositiveNumbers: true, expected: "+$1.00"),
+            .init(number: 0,  digits: 2, shouldDisplaySignForPositiveNumbers: true, expected: "$0.00"),
+            .init(number: -1,  digits: 2, shouldDisplaySignForPositiveNumbers: true, expected: "-$1.00")
+        ]
+        
+        for testCase in testCases {
+            let formatted = dydxFormatter.shared.dollarVolume(number: testCase.number, digits: testCase.digits, shouldDisplaySignForPositiveNumbers: testCase.shouldDisplaySignForPositiveNumbers)
+            XCTAssertEqual(formatted, testCase.expected)
+        }
+    }
+    
+    func testPercentFormatting() throws {
+        struct TestCase {
+            let number: Double
+            let digits: Int
+            let shouldDisplaySignForPositiveNumbers: Bool
+            let expected: String
+        }
+        
+        let testCases: [TestCase] = [
+            .init(number: 0.01,        digits: 2, shouldDisplaySignForPositiveNumbers: false, expected: "1.00%"),
+            .init(number: -0.00001,   digits: 0, shouldDisplaySignForPositiveNumbers: false, expected: "0%"),
+            .init(number: -0.00001,    digits: 3, shouldDisplaySignForPositiveNumbers: false,  expected: "-0.001%"),
+            .init(number: -0.00001,    digits: 2, shouldDisplaySignForPositiveNumbers: false,  expected: "0.00%"),
+            .init(number:  0.00001,    digits: 2, shouldDisplaySignForPositiveNumbers: false,  expected: "0.00%"),
+            .init(number: -0.00005,    digits: 2, shouldDisplaySignForPositiveNumbers: false,  expected: "0.00%"),
+            .init(number: -0.000051,   digits: 2, shouldDisplaySignForPositiveNumbers: false,  expected: "-0.01%"),
+            .init(number:  0.01,        digits: 2, shouldDisplaySignForPositiveNumbers: true,   expected: "+1.00%"),
+            .init(number:  0,           digits: 2, shouldDisplaySignForPositiveNumbers: true,   expected: "0.00%"),
+            .init(number: -0.01,        digits: 2, shouldDisplaySignForPositiveNumbers: true,   expected: "-1.00%")
+        ]
+        
+        for testCase in testCases {
+            let formatted = dydxFormatter.shared.percent(number: testCase.number, digits: testCase.digits, shouldDisplayPlusSignForPositiveNumbers: testCase.shouldDisplaySignForPositiveNumbers)
+            print(testCase)
+            XCTAssertEqual(formatted, testCase.expected)
+            print()
+        }
     }
 
     func testPerformanceExample() throws {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -20,7 +20,7 @@ final class dydxTransferSubaccountWorker: BaseWorker {
     override func start() {
         super.start()
 
-        AbacusStateManager.shared.state.accountBalance(of: .usdc)
+        AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom ?? "")
             .filter { value in
                 (value ?? 0) > dydxTransferSubaccountWorker.balanceRetainAmount
             }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -20,7 +20,7 @@ final class dydxTransferSubaccountWorker: BaseWorker {
     override func start() {
         super.start()
 
-        AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom ?? "")
+        AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom)
             .filter { value in
                 (value ?? 0) > dydxTransferSubaccountWorker.balanceRetainAmount
             }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
@@ -66,6 +66,7 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
         viewModel?.leverage = sharedOrderViewModel.leverage
         viewModel?.leverageIcon = sharedOrderViewModel.leverageIcon
         viewModel?.size = sharedOrderViewModel.size
+        viewModel?.side = sharedOrderViewModel.sideText
         viewModel?.token = sharedOrderViewModel.token
         viewModel?.logoUrl = sharedOrderViewModel.logoUrl
         viewModel?.gradientType = sharedOrderViewModel.gradientType

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
@@ -62,15 +62,16 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
         viewModel?.unrealizedPNLPercent = sharedOrderViewModel.unrealizedPnlPercent
 
         let sign: PlatformUISign
-        if position.realizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
-            sign = .plus
-        } else if position.realizedPnlPercent?.current?.doubleValue ?? 0 < 0 {
-            sign = .minus
-        } else {
+        let formattedPnl = dydxFormatter.shared.dollarVolume(number: abs(position.realizedPnl?.current?.doubleValue ?? 0), digits: 2)
+        let formattedZero = dydxFormatter.shared.dollarVolume(number: 0.00, digits: 2)
+        if formattedZero == formattedPnl {
             sign = .none
+        } else if position.realizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
+            sign = .plus
+        } else {
+            sign = .minus
         }
-        let pnl = dydxFormatter.shared.dollarVolume(number: abs(position.realizedPnl?.current?.doubleValue ?? 0), digits: 2)
-        viewModel?.realizedPNLAmount = SignedAmountViewModel(text: pnl, sign: sign, coloringOption: .signOnly)
+        viewModel?.realizedPNLAmount = SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)
 
         viewModel?.liquidationPrice = dydxFormatter.shared.dollar(number: position.liquidationPrice?.current?.doubleValue, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
@@ -60,19 +60,7 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
 
         viewModel?.unrealizedPNLAmount = sharedOrderViewModel.unrealizedPnl
         viewModel?.unrealizedPNLPercent = sharedOrderViewModel.unrealizedPnlPercent
-
-        let sign: PlatformUISign
-        let formattedPnl = dydxFormatter.shared.dollarVolume(number: abs(position.realizedPnl?.current?.doubleValue ?? 0), digits: 2)
-        let formattedZero = dydxFormatter.shared.dollarVolume(number: 0.00, digits: 2)
-        if formattedZero == formattedPnl {
-            sign = .none
-        } else if position.realizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
-            sign = .plus
-        } else {
-            sign = .minus
-        }
-        viewModel?.realizedPNLAmount = SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)
-
+        viewModel?.realizedPNLAmount = SignedAmountViewModel(amount: position.realizedPnl?.current?.doubleValue, displayType: .dollar, coloringOption: .allText)
         viewModel?.liquidationPrice = dydxFormatter.shared.dollar(number: position.liquidationPrice?.current?.doubleValue, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
         viewModel?.size = sharedOrderViewModel.size
@@ -85,15 +73,6 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
         viewModel?.openPrice = dydxFormatter.shared.dollar(number: position.entryPrice?.current?.doubleValue, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
         viewModel?.closePrice = dydxFormatter.shared.dollar(number: position.exitPrice?.doubleValue, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
-        let fundingSign: PlatformUISign
-        let funding = dydxFormatter.shared.dollarVolume(number: abs(position.netFunding?.doubleValue ?? 0), digits: 2)
-        if formattedZero == funding {
-            fundingSign = .none
-        } else if position.netFunding?.doubleValue ?? 0 > 0 {
-            fundingSign = .plus
-        } else {
-            fundingSign = .minus
-        }
-        viewModel?.funding = SignedAmountViewModel(text: funding, sign: fundingSign, coloringOption: .allText)
+        viewModel?.funding = SignedAmountViewModel(amount: position.netFunding?.doubleValue, displayType: .dollar, coloringOption: .allText)
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
@@ -86,14 +86,14 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
         viewModel?.closePrice = dydxFormatter.shared.dollar(number: position.exitPrice?.doubleValue, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
         let fundingSign: PlatformUISign
-        if position.netFunding?.doubleValue ?? 0 > 0 {
-            fundingSign = .plus
-        } else if position.netFunding?.doubleValue ?? 0 < 0 {
-            fundingSign = .minus
-        } else {
-            fundingSign = .none
-        }
         let funding = dydxFormatter.shared.dollarVolume(number: abs(position.netFunding?.doubleValue ?? 0), digits: 2)
-        viewModel?.funding = SignedAmountViewModel(text: funding, sign: fundingSign, coloringOption: .signOnly)
+        if formattedZero == funding {
+            fundingSign = .none
+        } else if position.netFunding?.doubleValue ?? 0 > 0 {
+            fundingSign = .plus
+        } else {
+            fundingSign = .minus
+        }
+        viewModel?.funding = SignedAmountViewModel(text: funding, sign: fundingSign, coloringOption: .allText)
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
@@ -72,12 +72,9 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
         let pnl = dydxFormatter.shared.dollarVolume(number: abs(position.realizedPnl?.current?.doubleValue ?? 0), digits: 2)
         viewModel?.realizedPNLAmount = SignedAmountViewModel(text: pnl, sign: sign, coloringOption: .signOnly)
 
-        viewModel?.leverage = sharedOrderViewModel.leverage
-        viewModel?.leverageIcon = sharedOrderViewModel.leverageIcon
         viewModel?.liquidationPrice = dydxFormatter.shared.dollar(number: position.liquidationPrice?.current?.doubleValue, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
         viewModel?.size = sharedOrderViewModel.size
-        viewModel?.side = sharedOrderViewModel.sideText
         viewModel?.token = sharedOrderViewModel.token
         viewModel?.logoUrl = sharedOrderViewModel.logoUrl
         viewModel?.gradientType = sharedOrderViewModel.gradientType

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -91,7 +91,7 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
         item.entryPrice = dydxFormatter.shared.dollar(number: position.entryPrice?.current, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
         item.unrealizedPnl = SignedAmountViewModel(amount: position.unrealizedPnl?.current?.doubleValue ?? 0, displayType: .dollar, coloringOption: .allText)
-        item.unrealizedPnlPercent = dydxFormatter.shared.percent(number: abs(position.unrealizedPnlPercent?.current?.doubleValue ?? 0), digits: 2)
+        item.unrealizedPnlPercent = dydxFormatter.shared.percent(number: position.unrealizedPnlPercent?.current?.doubleValue ?? 0, digits: 2)
 
         if let url = asset.resources?.imageUrl {
             item.logoUrl = URL(string: url)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -75,11 +75,11 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
         item.token?.symbol = asset.id
 
         if position.resources.indicator.current == "long" {
-            item.gradientType = .plus
             item.sideText.side = .long
+            item.gradientType = .plus
         } else {
-            item.gradientType = .minus
             item.sideText.side = .short
+            item.gradientType = .minus
        }
 
         item.leverage = dydxFormatter.shared.leverage(number: NSNumber(value: position.leverage?.current?.doubleValue ?? 0))
@@ -90,18 +90,7 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
         item.indexPrice = dydxFormatter.shared.dollar(number: market.oraclePrice, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
         item.entryPrice = dydxFormatter.shared.dollar(number: position.entryPrice?.current, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
-        let sign: PlatformUISign
-        let formattedPnl = dydxFormatter.shared.dollarVolume(number: abs(position.unrealizedPnl?.current?.doubleValue ?? 0), digits: 2)
-        let formattedZero = dydxFormatter.shared.dollarVolume(number: 0.00, digits: 2)
-        if formattedZero == formattedPnl {
-            sign = .none
-        } else if position.realizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
-            sign = .plus
-        } else {
-            sign = .minus
-        }
-        item.unrealizedPnl =  SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)
-
+        item.unrealizedPnl = SignedAmountViewModel(amount: position.unrealizedPnl?.current?.doubleValue ?? 0, displayType: .dollar, coloringOption: .allText)
         item.unrealizedPnlPercent = dydxFormatter.shared.percent(number: abs(position.unrealizedPnlPercent?.current?.doubleValue ?? 0), digits: 2)
 
         if let url = asset.resources?.imageUrl {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -71,21 +71,16 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
         let item = cache?[position.assetId] ?? dydxPortfolioPositionItemViewModel()
 
         let positionSize = abs(position.size?.current?.doubleValue ?? 0)
+        item.marketValue = dydxFormatter.shared.dollar(number: position.valueTotal?.current?.doubleValue)
         item.size = dydxFormatter.shared.localFormatted(number: positionSize, digits: configs.displayStepSizeDecimals?.intValue ?? 1)
         item.token?.symbol = asset.id
 
         if position.resources.indicator.current == "long" {
-            item.sideText.side = .long
             item.gradientType = .plus
         } else {
-            item.sideText.side = .short
             item.gradientType = .minus
        }
 
-        item.leverage = dydxFormatter.shared.leverage(number: NSNumber(value: position.leverage?.current?.doubleValue ?? 0))
-        if let leverage = position.leverage?.current?.doubleValue, let maxLeverage = position.maxLeverage?.current?.doubleValue, maxLeverage > 0 {
-            item.leverageIcon = LeverageRiskModel(level: LeverageRiskModel.Level(marginUsage: leverage / maxLeverage), viewSize: 16, displayOption: .iconOnly)
-        }
         item.indexPrice = dydxFormatter.shared.dollar(number: market.oraclePrice, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
         item.entryPrice = dydxFormatter.shared.dollar(number: position.entryPrice?.current, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -77,8 +77,10 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
 
         if position.resources.indicator.current == "long" {
             item.gradientType = .plus
+            item.sideText.side = .long
         } else {
             item.gradientType = .minus
+            item.sideText.side = .short
        }
 
         item.indexPrice = dydxFormatter.shared.dollar(number: market.oraclePrice, digits: configs.displayTickSizeDecimals?.intValue ?? 0)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -87,18 +87,18 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
         item.entryPrice = dydxFormatter.shared.dollar(number: position.entryPrice?.current, digits: configs.displayTickSizeDecimals?.intValue ?? 0)
 
         let sign: PlatformUISign
-        if position.unrealizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
-            sign = .plus
-        } else if position.unrealizedPnlPercent?.current?.doubleValue ?? 0 < 0 {
-            sign = .minus
-        } else {
+        let formattedPnl = dydxFormatter.shared.dollarVolume(number: abs(position.unrealizedPnl?.current?.doubleValue ?? 0), digits: 2)
+        let formattedZero = dydxFormatter.shared.dollarVolume(number: 0.00, digits: 2)
+        if formattedZero == formattedPnl {
             sign = .none
+        } else if position.realizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
+            sign = .plus
+        } else {    
+            sign = .minus
         }
-        let pnlPercent = dydxFormatter.shared.percent(number: abs(position.unrealizedPnlPercent?.current?.doubleValue ?? 0), digits: 2)
-        item.unrealizedPnlPercent = SignedAmountViewModel(text: pnlPercent, sign: sign, coloringOption: .allText)
+        item.unrealizedPnl = SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)
 
-        let pnl = dydxFormatter.shared.dollarVolume(number: abs(position.unrealizedPnl?.current?.doubleValue ?? 0), digits: 2)
-        item.unrealizedPnl =  SignedAmountViewModel(text: pnl, sign: sign, coloringOption: .signOnly)
+        item.unrealizedPnlPercent = dydxFormatter.shared.percent(number: abs(position.unrealizedPnlPercent?.current?.doubleValue ?? 0), digits: 2)
 
         if let url = asset.resources?.imageUrl {
             item.logoUrl = URL(string: url)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -96,7 +96,7 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
         } else {
             sign = .minus
         }
-        item.unrealizedPnl = SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)
+        item.unrealizedPnl =  SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)
 
         item.unrealizedPnlPercent = dydxFormatter.shared.percent(number: abs(position.unrealizedPnlPercent?.current?.doubleValue ?? 0), digits: 2)
 

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -93,7 +93,7 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
             sign = .none
         } else if position.realizedPnlPercent?.current?.doubleValue ?? 0 > 0 {
             sign = .plus
-        } else {    
+        } else {
             sign = .minus
         }
         item.unrealizedPnl = SignedAmountViewModel(text: formattedPnl, sign: sign, coloringOption: .allText)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileBalancesViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileBalancesViewPresenter.swift
@@ -32,7 +32,7 @@ public class dydxProfileBalancesViewPresenter: HostedViewPresenter<dydxProfileBa
     public override func start() {
         super.start()
 
-        AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
+        AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom)
             .sink { [weak self] dydxAmount in
                 if let dydxAmount = dydxAmount {
                     self?.viewModel?.walletAmount = dydxFormatter.shared.raw(number: Parser.standard.asNumber(dydxAmount), digits: 4)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileBalancesViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileBalancesViewPresenter.swift
@@ -32,7 +32,7 @@ public class dydxProfileBalancesViewPresenter: HostedViewPresenter<dydxProfileBa
     public override func start() {
         super.start()
 
-        AbacusStateManager.shared.state.accountBalance(of: .dydx)
+        AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
             .sink { [weak self] dydxAmount in
                 if let dydxAmount = dydxAmount {
                     self?.viewModel?.walletAmount = dydxFormatter.shared.raw(number: Parser.standard.asNumber(dydxAmount), digits: 4)
@@ -46,7 +46,7 @@ public class dydxProfileBalancesViewPresenter: HostedViewPresenter<dydxProfileBa
             }
             .store(in: &subscriptions)
 
-        AbacusStateManager.shared.state.stakingBalance(of: .dydx)
+        AbacusStateManager.shared.state.stakingBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
             .sink { [weak self] dydxAmount in
                 if let dydxAmount = dydxAmount {
                     self?.viewModel?.stakedAmount = dydxFormatter.shared.raw(number: Parser.standard.asNumber(dydxAmount), digits: 4)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
@@ -217,7 +217,7 @@ class dydxTransferInputCtaButtonViewPresenter: HostedViewPresenter<dydxTradeInpu
             AbacusStateManager.shared.state.transferInput,
             AbacusStateManager.shared.state.currentWallet,
             AbacusStateManager.shared.state.selectedSubaccount.compactMap { $0 },
-            AbacusStateManager.shared.state.accountBalance(of: .usdc)
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom ?? "")
         )
         .prefix(1)
         .sink { [weak self] transferInput, currentWallet, selectedSubaccount, usdcBalanceInWallet in
@@ -264,8 +264,8 @@ class dydxTransferInputCtaButtonViewPresenter: HostedViewPresenter<dydxTradeInpu
         Publishers.CombineLatest4(
             AbacusStateManager.shared.state.transferInput,
             AbacusStateManager.shared.state.currentWallet,
-            AbacusStateManager.shared.state.accountBalance(of: .usdc),
-            AbacusStateManager.shared.state.accountBalance(of: .dydx)
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom ?? ""),
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
         )
         .prefix(1)
         .map {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
@@ -217,7 +217,7 @@ class dydxTransferInputCtaButtonViewPresenter: HostedViewPresenter<dydxTradeInpu
             AbacusStateManager.shared.state.transferInput,
             AbacusStateManager.shared.state.currentWallet,
             AbacusStateManager.shared.state.selectedSubaccount.compactMap { $0 },
-            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom ?? "")
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom)
         )
         .prefix(1)
         .sink { [weak self] transferInput, currentWallet, selectedSubaccount, usdcBalanceInWallet in
@@ -264,8 +264,8 @@ class dydxTransferInputCtaButtonViewPresenter: HostedViewPresenter<dydxTradeInpu
         Publishers.CombineLatest4(
             AbacusStateManager.shared.state.transferInput,
             AbacusStateManager.shared.state.currentWallet,
-            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom ?? ""),
-            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom),
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom)
         )
         .prefix(1)
         .map {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
@@ -106,7 +106,7 @@ class dydxTransferOutViewPresenter: HostedViewPresenter<dydxTransferOutViewModel
             AbacusStateManager.shared.state.selectedSubaccount
                 .map(\.?.freeCollateral?.current)
                 .removeDuplicates(),
-            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom)
         )
             .sink { [weak self] selectedToken, freeCollateral, dydxTokenAmount in
                 if selectedToken?.type == dydxTokenConstants.usdcTokenKey {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
@@ -106,7 +106,7 @@ class dydxTransferOutViewPresenter: HostedViewPresenter<dydxTransferOutViewModel
             AbacusStateManager.shared.state.selectedSubaccount
                 .map(\.?.freeCollateral?.current)
                 .removeDuplicates(),
-            AbacusStateManager.shared.state.accountBalance(of: .dydx)
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom ?? "")
         )
             .sink { [weak self] selectedToken, freeCollateral, dydxTokenAmount in
                 if selectedToken?.type == dydxTokenConstants.usdcTokenKey {

--- a/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
@@ -109,7 +109,7 @@ public final class AbacusState {
      **/
     public enum NativeTokenDenom: String {
         case usdc = "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5"
-        case dydx = "dv4tnt"
+        case dydx = "adv4tnt"
     }
 
     public func accountBalance(of tokenDenom: NativeTokenDenom) -> AnyPublisher<Double?, Never> {

--- a/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
@@ -104,10 +104,10 @@ public final class AbacusState {
             .eraseToAnyPublisher()
     }
 
-    public func accountBalance(of tokenDenom: String) -> AnyPublisher<Double?, Never> {
+    public func accountBalance(of tokenDenom: String?) -> AnyPublisher<Double?, Never> {
         account
             .map { account in
-                self.parser.asDecimal(account?.balances?[tokenDenom]?.amount)?.doubleValue
+                self.parser.asDecimal(account?.balances?[tokenDenom ?? ""]?.amount)?.doubleValue
             }
             .removeDuplicates()
             .share()

--- a/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
@@ -104,28 +104,20 @@ public final class AbacusState {
             .eraseToAnyPublisher()
     }
 
-    /**
-     Account balances (wallet balances)
-     **/
-    public enum NativeTokenDenom: String {
-        case usdc = "ibc/8E27BA2D5493AF5636760E354E46004562C46AB7EC0CC4C1CA14E9E20E2545B5"
-        case dydx = "adv4tnt"
-    }
-
-    public func accountBalance(of tokenDenom: NativeTokenDenom) -> AnyPublisher<Double?, Never> {
+    public func accountBalance(of tokenDenom: String) -> AnyPublisher<Double?, Never> {
         account
             .map { account in
-                self.parser.asDecimal(account?.balances?[tokenDenom.rawValue]?.amount)?.doubleValue
+                self.parser.asDecimal(account?.balances?[tokenDenom]?.amount)?.doubleValue
             }
             .removeDuplicates()
             .share()
             .eraseToAnyPublisher()
     }
 
-    public func stakingBalance(of tokenDenom: NativeTokenDenom) -> AnyPublisher<Double?, Never> {
+    public func stakingBalance(of tokenDenom: String) -> AnyPublisher<Double?, Never> {
         account
             .map { account in
-                self.parser.asDecimal(account?.stakingBalances?[tokenDenom.rawValue]?.amount)?.doubleValue
+                self.parser.asDecimal(account?.stakingBalances?[tokenDenom]?.amount)?.doubleValue
             }
             .removeDuplicates()
             .share()

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -436,3 +436,13 @@ extension AbacusStateManager {
         }
     }
 }
+
+public extension V4Environment {
+    var usdcTokenInfo: TokenInfo? {
+        tokens["usdc"]
+    }
+
+    var dydxTokenInfo: TokenInfo? {
+        tokens["chain"]
+    }
+}

--- a/dydx/dydxViews/dydxViews.xcodeproj/project.pbxproj
+++ b/dydx/dydxViews/dydxViews.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		270BA8CF2A6F1470009212EA /* dydxDebugThemeViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270BA8CE2A6F1470009212EA /* dydxDebugThemeViewerView.swift */; };
 		270E7E342A5F700B00136793 /* dydxOrderbookManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 270E7E332A5F700B00136793 /* dydxOrderbookManagerView.swift */; };
 		272030182A7812B900D233B9 /* UINavigationController+SwipeBackNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 272030172A7812B900D233B9 /* UINavigationController+SwipeBackNavigation.swift */; };
+		273F50162B7C3F120034792A /* SignedAmountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 273F50152B7C3F120034792A /* SignedAmountView.swift */; };
 		2769090E2AAFD8030075B2D6 /* TransferInstanceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2769090D2AAFD8030075B2D6 /* TransferInstanceViewModel.swift */; };
 		276909102AAFD8BE0075B2D6 /* dydxPortfolioTransfersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2769090F2AAFD8BE0075B2D6 /* dydxPortfolioTransfersViewModel.swift */; };
 		277442972AD88C4900C91357 /* Satoshi-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 277442952AD88C4900C91357 /* Satoshi-Bold.otf */; };
@@ -498,6 +499,7 @@
 		270BA8CE2A6F1470009212EA /* dydxDebugThemeViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxDebugThemeViewerView.swift; sourceTree = "<group>"; };
 		270E7E332A5F700B00136793 /* dydxOrderbookManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxOrderbookManagerView.swift; sourceTree = "<group>"; };
 		272030172A7812B900D233B9 /* UINavigationController+SwipeBackNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SwipeBackNavigation.swift"; sourceTree = "<group>"; };
+		273F50152B7C3F120034792A /* SignedAmountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignedAmountView.swift; sourceTree = "<group>"; };
 		2769090D2AAFD8030075B2D6 /* TransferInstanceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferInstanceViewModel.swift; sourceTree = "<group>"; };
 		2769090F2AAFD8BE0075B2D6 /* dydxPortfolioTransfersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxPortfolioTransfersViewModel.swift; sourceTree = "<group>"; };
 		277442952AD88C4900C91357 /* Satoshi-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Satoshi-Bold.otf"; sourceTree = "<group>"; };
@@ -848,6 +850,7 @@
 				02031F022AC36CE60069E00D /* BuySellButton.swift */,
 				024FEB7D2ACB82A10087A55E /* NavHeader.swift */,
 				0273A15E2ACCDDB1001B89F5 /* SelectionBar.swift */,
+				273F50152B7C3F120034792A /* SignedAmountView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1945,6 +1948,7 @@
 				0273A15F2ACCDDB1001B89F5 /* SelectionBar.swift in Sources */,
 				02031F032AC36CE60069E00D /* BuySellButton.swift in Sources */,
 				02A5C858297FBCBE00FFE1F9 /* dydxTransferView.swift in Sources */,
+				273F50162B7C3F120034792A /* SignedAmountView.swift in Sources */,
 				0277A22528BD7B14005A51F8 /* WalletConnectionView.swift in Sources */,
 				025D22D428F6528F00C4ADAE /* dydxMarketStatsView.swift in Sources */,
 				02195E1F2A20229700F73C17 /* dydxMarketOrderbookView.swift in Sources */,

--- a/dydx/dydxViews/dydxViews/Shared/SignedAmountView.swift
+++ b/dydx/dydxViews/dydxViews/Shared/SignedAmountView.swift
@@ -1,0 +1,45 @@
+//
+//  SignedAmountView.swift
+//  dydxViews
+//
+//  Created by Michael Maguire on 2/13/24.
+//
+
+import PlatformUI
+import dydxFormatter
+
+public extension SignedAmountViewModel {
+    convenience init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption) {
+        self.init(text: text,
+                  sign: sign,
+                  coloringOption: coloringOption,
+                  positiveTextStyleKey: ThemeSettings.positiveTextStyleKey,
+                  negativeTextStyleKey: ThemeSettings.negativeTextStyleKey)
+    }
+
+    convenience init(amount: Double?, displayType: DisplayType, coloringOption: ColoringOption, shouldDisplaySignForPositiveNumbers: Bool = false) {
+        let formattedZero: String?
+        let formattedText: String?
+        let sign: PlatformUISign
+        switch displayType {
+        case .dollar:
+            formattedText = dydxFormatter.shared.dollarVolume(number: amount?.magnitude, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
+            formattedZero = dydxFormatter.shared.dollarVolume(number: 0.0, shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
+        case .percent:
+            let digits = 2
+            formattedText = dydxFormatter.shared.percent(number: amount?.magnitude, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
+            formattedZero = dydxFormatter.shared.percent(number: 0.0, digits: digits, shouldDisplayPlusSignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
+        }
+        // special logic for when a value like -0.001 would render as "-$0.00" instead of "$0.00"
+        if formattedText == formattedZero {
+            sign = .none
+        } else if (amount ?? 0) > 0 {
+            sign = .plus
+        } else {
+            sign = .minus
+        }
+        self.init(text: formattedText,
+                  sign: sign,
+                  coloringOption: coloringOption)
+    }
+}

--- a/dydx/dydxViews/dydxViews/Themes/dydxThemes.swift
+++ b/dydx/dydxViews/dydxViews/Themes/dydxThemes.swift
@@ -146,21 +146,6 @@ struct GradientTypeModifier: ViewModifier {
     }
 }
 
-public extension SignedAmountViewModel {
-    convenience init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption) {
-        self.init(text: text, sign: sign, coloringOption: coloringOption, positiveTextStyleKey: ThemeSettings.positiveTextStyleKey, negativeTextStyleKey: ThemeSettings.negativeTextStyleKey)
-    }
-
-    convenience init(amount: Double?, displayType: DisplayType, coloringOption: ColoringOption, shouldDisplaySignForPositiveNumbers: Bool = false) {
-        self.init(amount: amount,
-                  displayType: displayType,
-                  coloringOption: coloringOption,
-                  positiveTextStyleKey: ThemeSettings.positiveTextStyleKey,
-                  negativeTextStyleKey: ThemeSettings.negativeTextStyleKey,
-                  shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
-    }
-}
-
 private extension UIWindow {
 
     /// Unload all views and add back.

--- a/dydx/dydxViews/dydxViews/Themes/dydxThemes.swift
+++ b/dydx/dydxViews/dydxViews/Themes/dydxThemes.swift
@@ -147,7 +147,7 @@ struct GradientTypeModifier: ViewModifier {
 }
 
 public extension SignedAmountViewModel {
-    convenience init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption = .signOnly) {
+    convenience init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption) {
         self.init(text: text, sign: sign, coloringOption: coloringOption, positiveTextStyleKey: ThemeSettings.positiveTextStyleKey, negativeTextStyleKey: ThemeSettings.negativeTextStyleKey)
     }
 }

--- a/dydx/dydxViews/dydxViews/Themes/dydxThemes.swift
+++ b/dydx/dydxViews/dydxViews/Themes/dydxThemes.swift
@@ -150,6 +150,15 @@ public extension SignedAmountViewModel {
     convenience init(text: String? = nil, sign: PlatformUISign = .plus, coloringOption: ColoringOption) {
         self.init(text: text, sign: sign, coloringOption: coloringOption, positiveTextStyleKey: ThemeSettings.positiveTextStyleKey, negativeTextStyleKey: ThemeSettings.negativeTextStyleKey)
     }
+
+    convenience init(amount: Double?, displayType: DisplayType, coloringOption: ColoringOption, shouldDisplaySignForPositiveNumbers: Bool = false) {
+        self.init(amount: amount,
+                  displayType: displayType,
+                  coloringOption: coloringOption,
+                  positiveTextStyleKey: ThemeSettings.positiveTextStyleKey,
+                  negativeTextStyleKey: ThemeSettings.negativeTextStyleKey,
+                  shouldDisplaySignForPositiveNumbers: shouldDisplaySignForPositiveNumbers)
+    }
 }
 
 private extension UIWindow {

--- a/dydx/dydxViews/dydxViews/_v4/MarketInfo/Components/Position/dydxMarketPositionView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/MarketInfo/Components/Position/dydxMarketPositionView.swift
@@ -14,7 +14,7 @@ public class dydxMarketPositionViewModel: PlatformViewModel {
     @Published public var shareAction: (() -> Void)?
     @Published public var closeAction: (() -> Void)?
     @Published public var unrealizedPNLAmount: SignedAmountViewModel?
-    @Published public var unrealizedPNLPercent: SignedAmountViewModel?
+    @Published public var unrealizedPNLPercent: String?
     @Published public var realizedPNLAmount: SignedAmountViewModel?
     @Published public var leverage: String?
     @Published public var leverageIcon: LeverageRiskModel?
@@ -37,7 +37,7 @@ public class dydxMarketPositionViewModel: PlatformViewModel {
         vm.shareAction = {}
         vm.closeAction = {}
         vm.unrealizedPNLAmount = .previewValue
-        vm.unrealizedPNLPercent = .previewValue
+        vm.unrealizedPNLPercent = "0.00%"
         vm.realizedPNLAmount = .previewValue
         vm.leverage = "$12.00"
         vm.leverageIcon = .previewValue
@@ -100,22 +100,29 @@ public class dydxMarketPositionViewModel: PlatformViewModel {
                 .padding(.top, 8)
 
             HStack(alignment: .top, spacing: 0) {
-                let value = VStack(alignment: .leading) {
+                let unrealizedValue = VStack(alignment: .leading) {
                     unrealizedPNLAmount?
                         .createView(parentStyle: parentStyle.themeFont(fontSize: .large))
 
-                    unrealizedPNLPercent?
-                        .createView(parentStyle: parentStyle.themeFont(fontSize: .small))
+                    Text(unrealizedPNLPercent ?? "")
+                        .themeFont(fontType: .number, fontSize: .smaller)
+                        .themeColor(foreground: .textTertiary)
                 }.wrappedViewModel
 
-                self.createCollectionItem(parentStyle: parentStyle, title: DataLocalizer.localize(path: "APP.TRADE.UNREALIZED_PNL"), valueViewModel: value)
+                let realizedValue = VStack(alignment: .leading) {
+                    realizedPNLAmount?
+                        .createView(parentStyle: parentStyle.themeFont(fontSize: .large))
+                    Spacer()
+                }.wrappedViewModel
+
+                self.createCollectionItem(parentStyle: parentStyle, title: DataLocalizer.localize(path: "APP.TRADE.UNREALIZED_PNL"), valueViewModel: unrealizedValue)
                     .padding(.vertical, 16)
                     .frame(height: 96)
 
                 DividerModel().createView(parentStyle: parentStyle)
                     .frame(height: 82)
 
-                self.createCollectionItem(parentStyle: parentStyle, title: DataLocalizer.localize(path: "APP.TRADE.REALIZED_PNL"), valueViewModel: realizedPNLAmount)
+                self.createCollectionItem(parentStyle: parentStyle, title: DataLocalizer.localize(path: "APP.TRADE.REALIZED_PNL"), valueViewModel: realizedValue)
                     .padding(.vertical, 16)
                     .frame(height: 96)
             }

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -119,7 +119,7 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
     private func createMain(parentStyle: ThemeStyle) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 0) {
-                Text(marketValue ?? "$69.420")
+                Text(marketValue ?? "--")
                     .themeFont(fontType: .number, fontSize: .small)
 
                 HStack(spacing: 2) {

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -22,19 +22,21 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         public var onCloseAction: (() -> Void)?
     }
 
-    public init(marketValue: String? = nil, 
+    public init(marketValue: String? = nil,
                 size: String? = nil,
                 token: TokenTextViewModel? = TokenTextViewModel(),
-                indexPrice: String? = nil, 
+                sideText: SideTextViewModel = SideTextViewModel(),
+                indexPrice: String? = nil,
                 entryPrice: String? = nil,
                 unrealizedPnlPercent: SignedAmountViewModel? = nil,
-                unrealizedPnl: SignedAmountViewModel? = nil, 
+                unrealizedPnl: SignedAmountViewModel? = nil,
                 logoUrl: URL? = nil,
-                gradientType: GradientType = .none, 
+                gradientType: GradientType = .none,
                 onTapAction: (() -> Void)? = nil) {
         self.marketValue = marketValue
         self.size = size
         self.token = token
+        self.sideText = sideText
         self.indexPrice = indexPrice
         self.entryPrice = entryPrice
         self.unrealizedPnlPercent = unrealizedPnlPercent
@@ -47,6 +49,7 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
     public var marketValue: String?
     public var size: String?
     public var token: TokenTextViewModel?
+    public var sideText: SideTextViewModel
     public var indexPrice: String?
     public var entryPrice: String?
     public var unrealizedPnlPercent: SignedAmountViewModel?
@@ -59,6 +62,7 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         let item = dydxPortfolioPositionItemViewModel(
             size: "299",
             token: .previewValue,
+            sideText: .previewValue,
             indexPrice: "$1,200",
             entryPrice: "$1,200",
             unrealizedPnlPercent: .previewValue,
@@ -119,6 +123,8 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
                     .themeFont(fontType: .number, fontSize: .small)
 
                 HStack(spacing: 2) {
+                    sideText
+                        .createView(parentStyle: parentStyle.themeFont(fontSize: .smaller))
                     Text(size ?? "")
                         .themeFont(fontType: .number, fontSize: .smaller)
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -28,8 +28,8 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
                 sideText: SideTextViewModel = SideTextViewModel(),
                 indexPrice: String? = nil,
                 entryPrice: String? = nil,
-                unrealizedPnlPercent: SignedAmountViewModel? = nil,
                 unrealizedPnl: SignedAmountViewModel? = nil,
+                unrealizedPnlPercent: String? = nil,
                 logoUrl: URL? = nil,
                 gradientType: GradientType = .none,
                 onTapAction: (() -> Void)? = nil) {
@@ -39,8 +39,8 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         self.sideText = sideText
         self.indexPrice = indexPrice
         self.entryPrice = entryPrice
-        self.unrealizedPnlPercent = unrealizedPnlPercent
         self.unrealizedPnl = unrealizedPnl
+        self.unrealizedPnlPercent = unrealizedPnlPercent
         self.gradientType = gradientType
         self.logoUrl = logoUrl
         self.handler = Handler(onTapAction: onTapAction)
@@ -52,8 +52,8 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
     public var sideText: SideTextViewModel
     public var indexPrice: String?
     public var entryPrice: String?
-    public var unrealizedPnlPercent: SignedAmountViewModel?
     public var unrealizedPnl: SignedAmountViewModel?
+    public var unrealizedPnlPercent: String?
     public var logoUrl: URL?
     public var gradientType: GradientType
     public var handler: Handler?
@@ -65,8 +65,8 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
             sideText: .previewValue,
             indexPrice: "$1,200",
             entryPrice: "$1,200",
-            unrealizedPnlPercent: .previewValue,
             unrealizedPnl: .previewValue,
+            unrealizedPnlPercent: "$0.00",
             logoUrl: URL(string: "https://media.dydx.exchange/currencies/eth.png"),
             gradientType: .plus)
         return item
@@ -152,9 +152,11 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         HStack {
             Spacer()
             VStack(alignment: .trailing) {
-                unrealizedPnlPercent?.createView(parentStyle: parentStyle.themeFont(fontType: .number, fontSize: .small))
+                unrealizedPnl?.createView(parentStyle: parentStyle.themeFont(fontType: .number, fontSize: .small))
 
-                unrealizedPnl?.createView(parentStyle: parentStyle.themeFont(fontType: .number, fontSize: .smaller))
+                Text(unrealizedPnlPercent ?? "")
+                    .themeFont(fontType: .number, fontSize: .smaller)
+                    .themeColor(foreground: .textTertiary)
             }
         }
         .frame(maxWidth: 80)

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -37,9 +37,10 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         self.size = size
         self.token = token
         self.sideText = sideText
+        self.leverage = leverage
+        self.leverageIcon = leverageIcon
         self.indexPrice = indexPrice
         self.entryPrice = entryPrice
-        self.unrealizedPnl = unrealizedPnl
         self.unrealizedPnlPercent = unrealizedPnlPercent
         self.gradientType = gradientType
         self.logoUrl = logoUrl

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -22,12 +22,19 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         public var onCloseAction: (() -> Void)?
     }
 
-    public init(size: String? = nil, token: TokenTextViewModel? = TokenTextViewModel(), sideText: SideTextViewModel = SideTextViewModel(), leverage: String? = nil, leverageIcon: LeverageRiskModel? = nil, indexPrice: String? = nil, entryPrice: String? = nil, unrealizedPnlPercent: SignedAmountViewModel? = nil, unrealizedPnl: SignedAmountViewModel? = nil, logoUrl: URL? = nil, gradientType: GradientType = .none, onTapAction: (() -> Void)? = nil) {
+    public init(marketValue: String? = nil, 
+                size: String? = nil,
+                token: TokenTextViewModel? = TokenTextViewModel(),
+                indexPrice: String? = nil, 
+                entryPrice: String? = nil,
+                unrealizedPnlPercent: SignedAmountViewModel? = nil,
+                unrealizedPnl: SignedAmountViewModel? = nil, 
+                logoUrl: URL? = nil,
+                gradientType: GradientType = .none, 
+                onTapAction: (() -> Void)? = nil) {
+        self.marketValue = marketValue
         self.size = size
         self.token = token
-        self.sideText = sideText
-        self.leverage = leverage
-        self.leverageIcon = leverageIcon
         self.indexPrice = indexPrice
         self.entryPrice = entryPrice
         self.unrealizedPnlPercent = unrealizedPnlPercent
@@ -37,11 +44,9 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         self.handler = Handler(onTapAction: onTapAction)
     }
 
+    public var marketValue: String?
     public var size: String?
     public var token: TokenTextViewModel?
-    public var sideText = SideTextViewModel()
-    public var leverage: String?
-    public var leverageIcon: LeverageRiskModel?
     public var indexPrice: String?
     public var entryPrice: String?
     public var unrealizedPnlPercent: SignedAmountViewModel?
@@ -54,8 +59,6 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         let item = dydxPortfolioPositionItemViewModel(
             size: "299",
             token: .previewValue,
-            sideText: .previewValue,
-            leverage: "0.01x",
             indexPrice: "$1,200",
             entryPrice: "$1,200",
             unrealizedPnlPercent: .previewValue,
@@ -112,23 +115,14 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
     private func createMain(parentStyle: ThemeStyle) -> some View {
         HStack {
             VStack(alignment: .leading, spacing: 0) {
+                Text(marketValue ?? "$69.420")
+                    .themeFont(fontType: .number, fontSize: .small)
+
                 HStack(spacing: 2) {
                     Text(size ?? "")
-                        .themeFont(fontType: .number, fontSize: .small)
+                        .themeFont(fontType: .number, fontSize: .smaller)
 
                     token?.createView(parentStyle: parentStyle.themeFont(fontSize: .smallest))
-                }
-
-                HStack(spacing: 2) {
-                    sideText
-                        .createView(parentStyle: parentStyle.themeFont(fontSize: .smaller))
-
-                    Text("@")
-                        .themeFont(fontSize: .smaller)
-                        .themeColor(foreground: .textTertiary)
-
-                    Text(leverage ?? "")
-                        .themeFont(fontType: .number, fontSize: .smaller)
                 }
             }
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Shared/TransferInstanceViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Shared/TransferInstanceViewModel.swift
@@ -107,8 +107,8 @@ public class TransferInstanceViewModel: PlatformViewModel {
                 .themeFont(fontSize: .smaller)
                 .themeColor(foreground: .textTertiary)
                 .lineLimit(1)
-            SignedAmountViewModel(text: dydxFormatter.shared.dollarVolume(number: amount.magnitude), sign: type.sign, coloringOption: .signOnly)
-                .createView(parentStyle: parentStyle)
+            Text(dydxFormatter.shared.dollarVolume(number: amount) ?? "")
+                .themeColor(foreground: .textSecondary)
                 .themeFont(fontSize: .small)
         }
     }

--- a/dydx/dydxViews/dydxViews/_v4/Wallet/WalletConnectionView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Wallet/WalletConnectionView.swift
@@ -28,7 +28,7 @@ public class WalletConnectionViewModel: PlatformViewModel {
         vm.walletAddress = "0xAA...AAAA"
         vm.walletImageUrl = URL(string: "https://s3.amazonaws.com/dydx.exchange/logos/walletconnect/lg/9d373b43ad4d2cf190fb1a774ec964a1addf406d6fd24af94ab7596e58c291b2.jpeg")
         vm.equity = "$1234.50"
-        vm.pnl24hPercent = SignedAmountViewModel(text: "12%", sign: .plus)
+        vm.pnl24hPercent = SignedAmountViewModel(text: "12%", sign: .plus, coloringOption: .allText)
         return vm
     }()
 


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket:
- [MOB-94 : \[Jan23-2024 iOS Testing\] one number is fully green, other is just the + as green](https://linear.app/dydx/issue/MOB-94/[jan23-2024-ios-testing]-one-number-is-fully-green-other-is-just-the)
- [MOB-229 : Read token denom from env config instead of hard coding](https://linear.app/dydx/issue/MOB-229/read-token-denom-from-env-config-instead-of-hard-coding)



<br/>

## Description / Intuition
- updated signed number coloring based on web and design's guidance (position rows, market position view stats)
- ~display $$$ value of position~
- align realized pnl with unrealized pnl in market position view
- update token denom to read from config
- added tests for dydx formatting functions
- added parameter in formatting functions to force "+" prefix for positive numbers




<br/>

## Before/After Screenshots or Videos

| Web | Before | After |
|--------|--------|-------|
| no changes <img src=""> | no changes <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/2955d4c2-55f6-4051-b4a3-5b6bc7e1ecec"> | no changes <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/62bd6e65-80a0-40aa-9a38-d00add1cb051"> |
| match web color formatting <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/3477e4d5-0fd3-4a8f-ae0c-dc862d61ad1c"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/726bebb4-db24-4835-af76-c6b097c21e8b"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/85cefedd-97a8-4b29-aaf6-050c46bff48a"> |
| match web color formatting  <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/d4fba743-63f3-45f3-a9d4-e4af6529d024"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/fefe14a3-db4b-45ab-8380-1b47d7421ec4"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/215d8d42-7bc4-484f-9d1d-8f976f8cdb10"> |
| match web color formatting <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/62717364-4a5e-4436-915c-133db2c0321b"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/2745d93d-96df-4389-a545-5748386ff01c"> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/c5b7de63-5700-4d93-bfcc-753abfb8b062"> |
| <img src=""> | <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/7f897860-e7dc-457c-a1d6-24ba890e8c5e"> |



<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
