### PR TITLE
update bitrise to use `build_` prefix in builds created using the `deploy` workflow

### DIFF
--- a/dydxV4/bitrise/config.yml
+++ b/dydxV4/bitrise/config.yml
@@ -194,6 +194,7 @@ workflows:
     - git-tag-project-version-and-build-number@1:
         inputs:
         - bitrise_tag_xcodeproj_path: dydxV4/dydxV4.xcodeproj
+        - bitrise_tag_format: build_v_VERSION_(_BUILD_)
         - bitrise_tag_info_plist_path: dydxV4/dydxV4/info.plist
     - dsym-upload-to-crashlytics--no-cocoapods@0:
         inputs:


### PR DESCRIPTION
we want to reserve `vX.Y.Z` tags for releases so instead will use `build_vX.Y.Z(<build#>)` for builds for improved public clarity

note this has also been updated in bitrise CI/CD

![Screenshot 2024-02-20 at 1 25 58 PM](https://github.com/dydxprotocol/v4-native-ios/assets/149746839/cca0869e-266a-4e1a-8510-5d3213dd0323)
