### PR TITLE
MOB-250 : Add metric to track screenshot taken

### DIFF
--- a/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4.xcscheme
+++ b/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4.xcscheme
@@ -194,11 +194,19 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-FIRDebugEnabled"
+            argument = "-FIRAnalyticsDebugEnabled"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-FIRDebugDisabled"
+            argument = "-FIRAnalyticsVerboseLoggingEnabled"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-noFIRAnalyticsDebugEnabled"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-FIRAnalyticsVerboseLoggingDisabled"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [[MOB-250 : Add metric to track screenshot taken](https://linear.app/dydx/issue/MOB-250/add-metric-to-track-screenshot-taken)](https://linear.app/dydx/issue/MOB-250/add-metric-to-track-screenshot-taken)



<br/>

## Description / Intuition
- logs `screenshotcaptured` when screenshot is detected. also adds property to reflect the classname of the topmost viewcontroller screenshotted
- adds new Firebase logging arguments to scheme (note, these new args are still default off)

<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
