### PR TITLE
update app review pre-prompt to match design

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
@@ -235,7 +235,7 @@
                 },
                 "/rate_app":{
                     "destination":"dydxPresenters.dydxRateAppViewBuilder",
-                    "presentation":"popup"
+                    "presentation":"half"
                 },
                 "/restricted":{
                     "destination":"Restricted.storyboard",

--- a/dydx/dydxPresenters/dydxPresenters/_Features/settings.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/settings.json
@@ -38,7 +38,7 @@
                     "text" : "APP.HELP_MODAL.PROVIDE_FEEDBACK"
                 },
                 "link" : {
-                    "text" : "{APP_SCHEME}:///action/collect_feedback?context=settings"
+                    "text" : "{APP_SCHEME}:///action/rate_app?context=settings"
                 }
             }
         ]

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Actions/dydxCollectFeedbackActionBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Actions/dydxCollectFeedbackActionBuilder.swift
@@ -26,7 +26,6 @@ open class dydxCollectFeedbackAction: NSObject, NavigableProtocol {
                 Router.shared?.navigate(to: feedbackUrl, completion: { _, success in
                     completion?(nil, success)
                 })
-                Tracking.shared?.log(event: "CollectFeedbackDisplayed", data: nil)
                 completion?(nil, true)
             } else {
                 completion?(nil, false)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Actions/dydxCollectFeedbackActionBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Actions/dydxCollectFeedbackActionBuilder.swift
@@ -23,16 +23,10 @@ open class dydxCollectFeedbackAction: NSObject, NavigableProtocol {
         switch request?.path {
     case "/action/collect_feedback":
             if let feedbackUrl = URL(string: AbacusStateManager.shared.environment?.links?.feedback ?? "") {
-                let data: [String: String]?
-                if let shareSource = request?.params?["context"] as? String {
-                    data = ["source_context": shareSource]
-                } else {
-                    data = nil
-                }
                 Router.shared?.navigate(to: feedbackUrl, completion: { _, success in
                     completion?(nil, success)
                 })
-                Tracking.shared?.log(event: "CollectFeedbackDisplayed", data: data)
+                Tracking.shared?.log(event: "CollectFeedbackDisplayed", data: nil)
                 completion?(nil, true)
             } else {
                 completion?(nil, false)

--- a/dydx/dydxStateManager/dydxStateManager/Rating/dydxPointsRating.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Rating/dydxPointsRating.swift
@@ -127,12 +127,6 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
         if !dydxBoolFeatureFlag.enable_app_rating.isEnabled { return }
         Tracking.shared?.log(event: "PrepromptedForRating", data: stateData)
         Router.shared?.navigate(to: RoutingRequest(path: "/rate_app"), animated: true, completion: nil)
-
-        #if DEBUG
-            Console.shared.log("mock prompt for rating")
-        #else
-            SKStoreReviewController.requestReview()
-        #endif
     }
 
     ///    See discussion below:

--- a/dydx/dydxStateManager/dydxStateManager/Rating/dydxRatingService.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Rating/dydxRatingService.swift
@@ -10,6 +10,8 @@ import Foundation
 import Utilities
 
 public protocol dydxRatingProtocol {
+    var stateData: [String: Any] { get }
+
     func connectedWallet()
     func launchedApp()
     func orderCreated(orderId: String, orderCreatedTimestampMillis: TimeInterval)

--- a/dydx/dydxViews/dydxViews/_v4/Rating/dydxRateAppView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Rating/dydxRateAppView.swift
@@ -33,20 +33,20 @@ public class dydxRateAppViewModel: PlatformViewModel {
             guard let self = self else { return AnyView(PlatformView.nilView) }
 
             return VStack(alignment: .center, spacing: 24) {
-                        Text(DataLocalizer.shared?.localize(path: "APP.RATE_APP.QUESTION", params: nil) ?? "")
+                        Text(DataLocalizer.shared?.localize(path: "RATE_APP.QUESTION", params: nil) ?? "")
                             .themeFont(fontType: .text, fontSize: .large)
                             .themeColor(foreground: .textSecondary)
                         HStack(spacing: 16) {
-                            self.createButtonContent(title: DataLocalizer.shared?.localize(path: "APP.RATE_APP.YES", params: nil) ?? "",
+                            self.createButtonContent(title: DataLocalizer.shared?.localize(path: "RATE_APP.YES", params: nil) ?? "",
                                                      parentStyle: parentStyle,
                                                      styleKey: styleKey,
                                                      action: self.positiveRatingIntentAction)
-                            self.createButtonContent(title: DataLocalizer.shared?.localize(path: "APP.RATE_APP.NO", params: nil) ?? "",
+                            self.createButtonContent(title: DataLocalizer.shared?.localize(path: "RATE_APP.NO", params: nil) ?? "",
                                                      parentStyle: parentStyle,
                                                      styleKey: styleKey,
                                                      action: self.negativeRatingIntentAction)
                         }
-                        Text(DataLocalizer.shared?.localize(path: "APP.RATE_APP.DEFER", params: nil) ?? "")
+                        Text(DataLocalizer.shared?.localize(path: "RATE_APP.DEFER", params: nil) ?? "")
                             .themeColor(foreground: .textTertiary)
                             .themeFont(fontSize: .medium)
                             .onTapGesture {[weak self] in

--- a/dydx/dydxViews/dydxViews/_v4/Rating/dydxRateAppView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Rating/dydxRateAppView.swift
@@ -8,19 +8,7 @@
 
 import SwiftUI
 import PlatformUI
-
-// Define a UIViewRepresentable to use UIVisualEffectView in SwiftUI
-struct BlurView: UIViewRepresentable {
-    var style: UIBlurEffect.Style
-
-    func makeUIView(context: Context) -> UIVisualEffectView {
-        return UIVisualEffectView(effect: UIBlurEffect(style: style))
-    }
-
-    func updateUIView(_ uiView: UIVisualEffectView, context: Context) {
-        uiView.effect = UIBlurEffect(style: style)
-    }
-}
+import Utilities
 
 public class dydxRateAppViewModel: PlatformViewModel {
     @Published public var positiveRatingIntentAction: (() -> Void)?
@@ -32,54 +20,45 @@ public class dydxRateAppViewModel: PlatformViewModel {
         return vm
     }()
 
-    private func createButtonContent(title: String) -> AnyView {
-        HStack {
-            Spacer()
-            Text(title)
-                .themeFont(fontSize: .medium)
-                .themeColor(foreground: .textPrimary)
-            Spacer()
-        }.wrappedInAnyView()
+    private func createButtonContent(title: String, parentStyle: ThemeStyle, styleKey: String?, action: (() -> Void)?) -> PlatformView {
+        PlatformButtonViewModel(
+            content: Text(title).wrappedViewModel,
+            state: .secondary,
+            action: { action?() })
+        .createView(parentStyle: parentStyle, styleKey: styleKey)
     }
 
     public override func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformView {
         PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] _  in
             guard let self = self else { return AnyView(PlatformView.nilView) }
 
-            return ZStack {
-                Color.clear // Use clear color for the background to show the blur effect
-                    .background(BlurView(style: .systemMaterialDark))
-                    .edgesIgnoringSafeArea(.all)
-                    .opacity(0.8)
-
-                ZStack(alignment: .center) {
-                    VStack(spacing: 32) {
-                        Text("Placholder\nare you enjoying this app?")
-                            .themeFont(fontSize: .large)
-                            .themeColor(foreground: .textPrimary)
-                        HStack {
-                            PlatformButtonViewModel(content: self.createButtonContent(title: "no").wrappedViewModel) { [weak self] in
-                                self?.negativeRatingIntentAction?()
-                            }.createView(parentStyle: parentStyle, styleKey: styleKey)
-                            PlatformButtonViewModel(content: self.createButtonContent(title: "yes").wrappedViewModel) { [weak self] in
-                                self?.positiveRatingIntentAction?()
-                            }.createView(parentStyle: parentStyle, styleKey: styleKey)
-                        }
-                        Text("later")
+            return VStack(alignment: .center, spacing: 24) {
+                        Text(DataLocalizer.shared?.localize(path: "APP.RATE_APP.QUESTION", params: nil) ?? "")
+                            .themeFont(fontType: .text, fontSize: .large)
                             .themeColor(foreground: .textSecondary)
+                        HStack(spacing: 16) {
+                            self.createButtonContent(title: DataLocalizer.shared?.localize(path: "APP.RATE_APP.YES", params: nil) ?? "",
+                                                     parentStyle: parentStyle,
+                                                     styleKey: styleKey,
+                                                     action: self.positiveRatingIntentAction)
+                            self.createButtonContent(title: DataLocalizer.shared?.localize(path: "APP.RATE_APP.NO", params: nil) ?? "",
+                                                     parentStyle: parentStyle,
+                                                     styleKey: styleKey,
+                                                     action: self.negativeRatingIntentAction)
+                        }
+                        Text(DataLocalizer.shared?.localize(path: "APP.RATE_APP.DEFER", params: nil) ?? "")
+                            .themeColor(foreground: .textTertiary)
                             .themeFont(fontSize: .medium)
                             .onTapGesture {[weak self] in
                                 self?.deferAction?()
                             }
                     }
-                    .padding(.all, 16)
-                }
-                .themeColor(background: .layer1)
-                .borderAndClip(style: .cornerRadius(8), borderColor: .borderDefault, lineWidth: 1)
-                .padding(.horizontal, 32)
-            }
-
-            .wrappedInAnyView()
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 46)
+                    .themeColor(background: .layer4)
+                    .makeSheet(sheetStyle: .fitSize)
+                    .ignoresSafeArea(edges: .bottom)
+                    .wrappedInAnyView()
         }
     }
 }


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-241 : implement pre-prompt before requesting app review](https://linear.app/dydx/issue/MOB-241/implement-pre-prompt-before-requesting-app-review)

Figma Design: [figma](https://www.figma.com/file/mKevZOfE9nj6MZpiolKYW1/dYdX-%E2%80%BA-Mobile?type=design&node-id=5543-1950&mode=design&t=63pQy2VbsBjNX6eg-0)




<br/>

## Description / Intuition
- updates the pre-prompt to match new design

@johnqh please also see [this comment](https://github.com/dydxprotocol/v4-localization/pull/322#issuecomment-1981366568) but as a reminder

- a user will never see the pre-prompt again if they tap "Yes"
- a user will see the pre-prompt again if they tap "Not really" or "Dismiss" AND they have re-met the conditions. Note conditions are reset between each pre-prompt display per the [previous PR](https://github.com/dydxprotocol/v4-native-ios/pull/102). Conditions are:
  - 8+ orders OR
  - 2+ transfers
  - screenshot or share the app





<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/0ab199da-fb4f-4237-a019-8fed7ffa6d37"> |







<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
