### PR TITLE
MOB-259 : Add metric to track time on each screen

### DIFF
--- a/AppsFlyerStaticInjections/AppsFlyerStaticInjections/_Tracking/AppsFlyerTracking.swift
+++ b/AppsFlyerStaticInjections/AppsFlyerStaticInjections/_Tracking/AppsFlyerTracking.swift
@@ -30,7 +30,7 @@ public class AppsFlyerTracking: TransformerTracker {
         }
     }
 
-    override open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
+    override open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
         // Only track the ones required by growth
     }
 

--- a/PlatformParticles/PlatformParticles/_Tracking/TransformerTracker.swift
+++ b/PlatformParticles/PlatformParticles/_Tracking/TransformerTracker.swift
@@ -10,6 +10,7 @@ import ParticlesKit
 import Utilities
 
 open class TransformerTracker: NSObject & TrackingProtocol {
+    
     open var userInfo: [String: String?]?
 
     public var excluded: Bool = false
@@ -25,7 +26,7 @@ open class TransformerTracker: NSObject & TrackingProtocol {
         }
     }
 
-    open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
+    open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
         if !excluded {
             if let path = transform(path: path)?.trim() {
                 if let action = action {

--- a/PlatformParticles/PlatformParticles/_ViewController/TrackingViewController.swift
+++ b/PlatformParticles/PlatformParticles/_ViewController/TrackingViewController.swift
@@ -35,7 +35,7 @@ open class TrackingViewController: NavigableViewController, TrackingViewProtocol
     open func logView(path: String?, data: [String: Any]?, from: String?, time: Date?) {
         if let path = path, trackingData?.path != path {
             trackingData = TrackingData(path: path, data: data)
-            Tracking.shared?.view(path, data: data, from: from, time: time)
+            Tracking.shared?.view(path, data: data, from: from, time: time, revenue: nil, contextViewController: self)
         }
     }
 }

--- a/Utilities/Utilities/_Tracker/_Shared/CompositeTracking.swift
+++ b/Utilities/Utilities/_Tracker/_Shared/CompositeTracking.swift
@@ -39,9 +39,9 @@ open class CompositeTracking: NSObject & TrackingProtocol {
         }
     }
 
-    open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
+    open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
         for tracking: TrackingProtocol in trackings {
-            tracking.view(path, action: action, data: data, from: from, time: time, revenue: revenue)
+            tracking.view(path, action: action, data: data, from: from, time: time, revenue: revenue, contextViewController: nil)
         }
     }
 

--- a/Utilities/Utilities/_Tracker/_Shared/DebugTracking.swift
+++ b/Utilities/Utilities/_Tracker/_Shared/DebugTracking.swift
@@ -13,7 +13,7 @@ public class DebugTracking: NSObject & TrackingProtocol {
 
     public var excluded: Bool = false
 
-    public func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
+    public func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
         if let path = path {
             let action = action ?? ""
             let from = from ?? ""

--- a/Utilities/Utilities/_Tracker/_Shared/Tracking.swift
+++ b/Utilities/Utilities/_Tracker/_Shared/Tracking.swift
@@ -11,23 +11,26 @@ import Foundation
 public protocol TrackingProtocol: NSObjectProtocol {
     var userInfo: [String: String?]? { get set }
     var excluded: Bool { get set }
-    func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?)
+    func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?)
     func leave(_ path: String?)
     func log(event: String, data: [String: Any]?, revenue: NSNumber?)
 }
 
 public extension TrackingProtocol {
+    func view(_ path: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
+        view(path, action: nil, data: data, from: from, time: time, revenue: revenue, contextViewController: contextViewController)
+    }
     func view(_ path: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
-        view(path, action: nil, data: data, from: from, time: time, revenue: revenue)
+        view(path, action: nil, data: data, from: from, time: time, revenue: revenue, contextViewController: nil)
     }
     func view(_ path: String?, data: [String: Any]?, from: String?, time: Date?) {
-        view(path, action: nil, data: data, from: from, time: time, revenue: nil)
+        view(path, action: nil, data: data, from: from, time: time, revenue: nil, contextViewController: nil)
     }
-    func view(_ path: String?, data: [String: Any]?, from: String?) {
-        view(path, action: nil, data: data, from: from, time: nil, revenue: nil)
+    func view(_ path: String?, data: [String: Any]?, from: String?, contextViewController: UIViewController?) {
+        view(path, action: nil, data: data, from: from, time: nil, revenue: nil, contextViewController: nil)
     }
     func view(_ path: String?, data: [String: Any]?) {
-        view(path, action: nil, data: data, from: nil, time: nil, revenue: nil)
+        view(path, action: nil, data: data, from: nil, time: nil, revenue: nil, contextViewController: nil)
     }
     func log(event: String, data: [String: Any]?) {
         log(event: event, data: data, revenue: nil)

--- a/dydxV4/dydxV4/_Tracking/dydxAmplitudeTracking.swift
+++ b/dydxV4/dydxV4/_Tracking/dydxAmplitudeTracking.swift
@@ -7,9 +7,10 @@
 //
 
 import AmplitudeInjections
+import UIKit
 
 public class dydxAmplitudeTracking: AmplitudeTracking {
-    override open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
+    override open func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
         // Only track the ones required by growth
     }
 

--- a/dydxV4/dydxV4/_Tracking/dydxCompositeTracking.swift
+++ b/dydxV4/dydxV4/_Tracking/dydxCompositeTracking.swift
@@ -11,6 +11,7 @@ import Utilities
 import dydxStateManager
 import Combine
 import Cartera
+import FirebaseAnalytics
 
 enum UserProperty: String {
     case walletAddress
@@ -79,13 +80,21 @@ public class dydxCompositeTracking: CompositeTracking {
 
     
 
-    override public func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?) {
+    override public func view(_ path: String?, action: String?, data: [String: Any]?, from: String?, time: Date?, revenue: NSNumber?, contextViewController: UIViewController?) {
         if let transformed = transform(events: viewEvents, path: path), let event = parser.asString(transformed["event"]) {
-            super.view(path, action: action, data: data, from: from, time: time, revenue: nil)
+            super.view(path, action: action, data: data, from: from, time: time, revenue: nil, contextViewController: contextViewController)
             let info = parser.asDictionary(transformed["info"]) ?? data ?? [String: Any]()
             log(event: event, data: info, revenue: revenue)
         } else {
-            super.view(path, action: action, data: data, from: from, time: time, revenue: revenue)
+            super.view(path, action: action, data: data, from: from, time: time, revenue: revenue, contextViewController: contextViewController)
+        }
+        if let contextViewController {
+            
+            log(event: AnalyticsEventScreenView,
+                data: [
+                    AnalyticsParameterScreenName: path as Any,
+                    AnalyticsParameterScreenClass: String(describing: type(of: contextViewController))
+                ])
         }
         if let transformed = transform(events: onboardingEvents, path: path), let event = parser.asString(transformed["event"]) {
             var info = parser.asDictionary(transformed["info"]) ?? data ?? [String: Any]()


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-259 : Add metric to track time on each screen](https://linear.app/dydx/issue/MOB-259/add-metric-to-track-time-on-each-screen)



<br/>

## Description / Intuition
- add `screen_view` event so that firebase analytics dashboard does automatic screen visit/screen time analysis

[documentation](https://firebase.google.com/docs/analytics/screenviews#disable_screenview_tracking)

> Google Analytics tracks screen transitions and attaches information about the current screen to events, enabling you to track metrics such as user engagement or user behavior per screen. Much of this data collection happens automatically, but you can also manually log screenviews. Manually tracking screens is useful if your app does not use a separate UIViewController, View, or Activity for each screen you may wish to track, such as in a game.

> You can manually log screen_view events whether or not automatic tracking is enabled. You can log these events in the onAppear or viewDidAppear methods for Apple platforms and onResume for Android. When screen_class is not set, Analytics sets a default value based on the UIViewController or Activity that is in focus when the call is made.

<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/814fe58b-4092-4b6a-a3ba-c6abfdcaeb52"> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/3975ca61-d575-4b89-8957-053c0baf7589"> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/755b026a-5cc2-4bdd-b830-18e205f8a6d8"> |



<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
