### PR TITLE
MOB-309 : add additional logic to rate app flow where `requestReview` API is called without pre-prompt IF the pre-prompt has been answer "yes" in the past

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Rating/dydxRateAppViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Rating/dydxRateAppViewBuilder.swift
@@ -62,7 +62,7 @@ private class dydxRateAppViewBuilderPresenter: HostedViewPresenter<dydxRateAppVi
             #else
                 SKStoreReviewController.requestReview()
             #endif
-            dydxRatingService.shared?.disablePrompting()
+            dydxRatingService.shared?.disablePreprompting()
             Router.shared?.navigate(to: RoutingRequest(path: "/action/dismiss"), animated: true, completion: nil)
         }
 

--- a/dydx/dydxStateManager/dydxStateManager/Rating/dydxPointsRating.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Rating/dydxPointsRating.swift
@@ -38,7 +38,7 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
         "last_prompted_timestamp": lastPromptedTimestamp,
         "has_ever_connected_wallet": hasEverConnectedWallet,
         "has_shared_or_screenshotted": hasSharedOrScreenshottedSinceLastPrompt,
-        "should_stop_pre_prompting": shouldStopPreprompting
+        "should_stop_preprompting": shouldStopPreprompting
     ]}
 
     public func connectedWallet() {
@@ -127,7 +127,7 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
         guard dydxBoolFeatureFlag.enable_app_rating.isEnabled else { return }
         if shouldStopPreprompting {
             #if DEBUG
-                Console.shared.log("log prompt for rating")
+                Console.shared.log("Simulate SKStoreReviewController.requestReview")
             #else
                 SKStoreReviewController.requestReview()
             #endif

--- a/dydx/dydxStateManager/dydxStateManager/Rating/dydxPointsRating.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Rating/dydxPointsRating.swift
@@ -23,7 +23,7 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
         case lastPromptedTimestamp
         case hasEverConnectedWallet
         case hasSharedOrScreenshottedSinceLastPrompt
-        case shouldStopPrompting
+        case shouldStopPreprompting
 
         var storeKey: String { "\(String(describing: dydxPointsRating.self)).\(self.rawValue)Key" }
     }
@@ -38,7 +38,7 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
         "last_prompted_timestamp": lastPromptedTimestamp,
         "has_ever_connected_wallet": hasEverConnectedWallet,
         "has_shared_or_screenshotted": hasSharedOrScreenshottedSinceLastPrompt,
-        "should_stop_prompting": shouldStopPrompting
+        "should_stop_pre_prompting": shouldStopPreprompting
     ]}
 
     public func connectedWallet() {
@@ -73,8 +73,8 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
         }
     }
 
-    public func disablePrompting() {
-        shouldStopPrompting = true
+    public func disablePreprompting() {
+        shouldStopPreprompting = true
     }
 
     /// this is maintained as a set for easier order count de-duping
@@ -117,16 +117,25 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
     }
 
     /// whether the user has continued to app store review after pre-prompt
-    var shouldStopPrompting: Bool {
-        get { UserDefaults.standard.bool(forKey: Key.shouldStopPrompting.storeKey) }
-        set { UserDefaults.standard.set(newValue, forKey: Key.shouldStopPrompting.storeKey) }
+    var shouldStopPreprompting: Bool {
+        get { UserDefaults.standard.bool(forKey: Key.shouldStopPreprompting.storeKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Key.shouldStopPreprompting.storeKey) }
     }
 
     public func promptForRating() {
         // feature flag in case the prompt has issues
-        if !dydxBoolFeatureFlag.enable_app_rating.isEnabled { return }
-        Tracking.shared?.log(event: "PrepromptedForRating", data: stateData)
-        Router.shared?.navigate(to: RoutingRequest(path: "/rate_app"), animated: true, completion: nil)
+        guard dydxBoolFeatureFlag.enable_app_rating.isEnabled else { return }
+        if shouldStopPreprompting {
+            #if DEBUG
+                Console.shared.log("log prompt for rating")
+            #else
+                SKStoreReviewController.requestReview()
+            #endif
+        } else {
+            Tracking.shared?.log(event: "PrepromptedForRating", data: stateData)
+            Router.shared?.navigate(to: RoutingRequest(path: "/rate_app"), animated: true, completion: nil)
+            reset()
+        }
     }
 
     ///    See discussion below:
@@ -148,14 +157,12 @@ open class dydxPointsRating: NSObject, dydxRatingProtocol {
     ///            - trader has shared a screenshot or the app
     ///            - trader has created 8 or more orders
     open func tryPromptForRating() {
-        guard !shouldStopPrompting else { return }
         let shouldPrompt =
             hasSharedOrScreenshottedSinceLastPrompt
             || (hasEverConnectedWallet && (uniqueDayAppOpensCount >= 8 || transfersCreatedSinceLastPrompt.count >= 2 || ordersCreatedSinceLastPrompt.count >= 8))
             || (!hasEverConnectedWallet && uniqueDayAppOpensCount >= 4)
         if shouldPrompt {
             promptForRating()
-            reset()
         }
     }
 

--- a/dydx/dydxStateManager/dydxStateManager/Rating/dydxRatingService.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Rating/dydxRatingService.swift
@@ -17,7 +17,7 @@ public protocol dydxRatingProtocol {
     func orderCreated(orderId: String, orderCreatedTimestampMillis: TimeInterval)
     func transferCreated(transferId: String, transferCreatedTimestampMillis: TimeInterval)
     func capturedScreenshotOrShare()
-    func disablePrompting()
+    func disablePreprompting()
 
     func promptForRating()
     func tryPromptForRating()

--- a/dydx/dydxStateManager/dydxStateManagerTests/dydxPointsRatingTests.swift
+++ b/dydx/dydxStateManager/dydxStateManagerTests/dydxPointsRatingTests.swift
@@ -15,9 +15,10 @@ private class TestPointsRating: dydxPointsRating {
     var promptWasReached: Bool = false
 
     override func promptForRating() {
+        guard !shouldStopPreprompting else { return }
         promptWasReached = true
+        reset()
     }
-
 }
 
 final class dydxPointsRatingTests: XCTestCase {
@@ -62,7 +63,7 @@ final class dydxPointsRatingTests: XCTestCase {
         XCTAssertEqual(testPointRating.promptWasReached, false)
     }
 
-    func testConnectedWalletAndMultipleAppLaunchesAndDisablePrompting() {
+    func testConnectedWalletAndMultipleAppLaunchesAndDisablePreprompting() {
         testPointRating.connectedWallet()
         for i in 1...8 {
             Thread.sleep(forTimeInterval: testPointRating.secondsInADay)
@@ -80,7 +81,7 @@ final class dydxPointsRatingTests: XCTestCase {
         }
         testPointRating.promptWasReached = false
 
-        testPointRating.disablePrompting()
+        testPointRating.disablePreprompting()
         for i in 1...8 {
             Thread.sleep(forTimeInterval: testPointRating.secondsInADay)
             testPointRating.launchedApp()

--- a/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4.xcscheme
+++ b/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4.xcscheme
@@ -205,19 +205,19 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "-FIRAnalyticsDebugEnabled"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-FIRAnalyticsVerboseLoggingEnabled"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-noFIRAnalyticsDebugEnabled"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-FIRAnalyticsVerboseLoggingDisabled"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-309 : add additional logic to rate app flow where `requestReview` API is called without pre-prompt IF the pre-prompt has been answer "yes" in the past](https://linear.app/dydx/issue/MOB-309/add-additional-logic-to-rate-app-flow-where-requestreview-api-is)



<br/>

## Description / Intuition
- directly make `requestReview` API calls after pre-prompt has been answered "yes" to. This way, if a trader answers "yes" to the pre-prompt but then "cancel" to the system prompt, they will be re-asked for a review later.




<br/>

## Before/After Screenshots or Videos
![Screenshot 2024-03-07 at 6 38 57 PM](https://github.com/dydxprotocol/v4-native-ios/assets/149746839/3d9bcb8b-dcfe-49b7-814e-93e649664470)



<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
