### PR TITLE
MOB-308: iOS: Handle deposit flow when user onboarded via Desktop Scan

### DIFF
--- a/PlatformUI/PlatformUI/Components/Buttons/PlatformButton.swift
+++ b/PlatformUI/PlatformUI/Components/Buttons/PlatformButton.swift
@@ -13,7 +13,7 @@ public enum PlatformButtonState {
 }
 
 public enum PlatformButtonType {
-    case defaultType, iconType, pill, small
+    case defaultType(fillWidth: Bool), iconType, pill, small
 }
 
 public class PlatformButtonViewModel<Content: PlatformViewModeling>: PlatformViewModel {
@@ -22,7 +22,10 @@ public class PlatformButtonViewModel<Content: PlatformViewModeling>: PlatformVie
     @Published public var type: PlatformButtonType
     @Published public var state: PlatformButtonState
     
-    public init(content: Content, type: PlatformButtonType = .defaultType, state: PlatformButtonState = .primary, action: @escaping () -> ()) {
+    public init(content: Content,
+                type: PlatformButtonType = .defaultType(fillWidth: true),
+                state: PlatformButtonState = .primary,
+                action: @escaping () -> ()) {
         self.action = action
         self.content = content
         self.type = type
@@ -37,19 +40,25 @@ public class PlatformButtonViewModel<Content: PlatformViewModeling>: PlatformVie
             return AnyView(
                 Group {
                     switch self.type {
-                    case .defaultType:
+                    case .defaultType(let fillWidth):
                        let button = Button(action: self.action) {
                             HStack {
-                                Spacer()
+                                if fillWidth {
+                                    Spacer()
+                                }
                                 self.content
                                     .createView(parentStyle: style.themeFont(fontType: .bold), styleKey: self.buttonStyleKey)
-                                Spacer()
+                                if fillWidth {
+                                    Spacer()
+                                }
                             }
                         }
                         .buttonStyle(BorderlessButtonStyle())
                         .disabled(disabled)
                         .padding(.all, 14)
-                        .frame(maxWidth: .infinity)
+                        .if(fillWidth) { view in
+                            view.frame(maxWidth: .infinity)
+                        }
                         .themeStyle(styleKey: self.buttonStyleKey, parentStyle: style)
                         .cornerRadius(8)
                         

--- a/PlatformUI/PlatformUI/DesignSystem/Theme/ThemeViewModifiers.swift
+++ b/PlatformUI/PlatformUI/DesignSystem/Theme/ThemeViewModifiers.swift
@@ -667,3 +667,15 @@ struct DisableBouncesModifier: ViewModifier {
           }
   }
 }
+
+// MARK: Conditional
+
+public extension View {
+    @ViewBuilder func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Actions/WalletAction.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Actions/WalletAction.swift
@@ -33,7 +33,8 @@ public class WalletAction: NSObject, NavigableProtocol {
             completion?(nil, true)
 
         case "/action/wallet/disconnect":
-            WalletAction.shared?.disconnect(ethereumAddress: parser.asString(request?.params?["ethereumAddress"]))
+            let ethereumAddress = parser.asString(request?.params?["ethereumAddress"])
+            WalletAction.shared?.disconnect(ethereumAddress: ethereumAddress)
             completion?(nil, true)
 
         case "/action/wallet/etherscan":
@@ -64,18 +65,16 @@ private class WalletActionImp: WalletActionProtocol {
     }
 
     public func disconnect(ethereumAddress: String?) {
-        if let ethereumAddress = ethereumAddress {
-            let prompter = PrompterFactory.shared?.prompter()
-            let signout = PrompterAction(title: DataLocalizer.localize(path: "APP.GENERAL.SIGN_OUT"), style: .destructive, enabled: true) { [weak self] in
-                self?.reallyDisconnect(ethereumAddress: ethereumAddress)
-            }
-            let cancel = PrompterAction(title: DataLocalizer.localize(path: "APP.GENERAL.CANCEL"), style: .cancel, enabled: true, selection: nil)
-            prompter?.title = DataLocalizer.localize(path: "APP.GENERAL.SIGN_OUT_WARNING")
-            prompter?.prompt([signout, cancel])
+        let prompter = PrompterFactory.shared?.prompter()
+        let signout = PrompterAction(title: DataLocalizer.localize(path: "APP.GENERAL.SIGN_OUT"), style: .destructive, enabled: true) { [weak self] in
+            self?.reallyDisconnect()
         }
+        let cancel = PrompterAction(title: DataLocalizer.localize(path: "APP.GENERAL.CANCEL"), style: .cancel, enabled: true, selection: nil)
+        prompter?.title = DataLocalizer.localize(path: "APP.GENERAL.SIGN_OUT_WARNING")
+        prompter?.prompt([signout, cancel])
     }
 
-    private func reallyDisconnect(ethereumAddress: String) {
+    private func reallyDisconnect() {
         AbacusStateManager.shared.disconnectAndReplaceCurrentWallet()
         Tracking.shared?.log(event: "DisconnectWallet", data: nil)
     }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Onboarding/Scan/dydxOnboardScanViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Onboarding/Scan/dydxOnboardScanViewBuilder.swift
@@ -151,11 +151,13 @@ private class dydxOnboardScanViewPresenter: HostedViewPresenter<dydxOnboardScanV
             showingError = false
             if let address = parser.asString(json["cosmosAddress"]), let mnemonic = parser.asString(json["mnemonic"]) {
                 // TODO: parse ethereum address when it becomes available in the Sync with Desktop QR Scan flow
-                AbacusStateManager.shared.setV4(ethereumAddress: address,
+                AbacusStateManager.shared.setV4(ethereumAddress: nil,
                                                 walletId: nil,
                                                 cosmoAddress: address,
                                                 mnemonic: mnemonic)
-                Router.shared?.navigate(to: RoutingRequest(path: "/portfolio", params: ["ethereumAddress": address]), animated: true, completion: nil)
+                Router.shared?.navigate(to: RoutingRequest(path: "/portfolio",
+                                                           params: ["cosmoAddress": address, "mnemonic": mnemonic]),
+                                        animated: true, completion: nil)
             } else {
                 showingError = true
             }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Onboarding/WalletList/dydxWalletListViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Onboarding/WalletList/dydxWalletListViewBuilder.swift
@@ -28,6 +28,8 @@ private class dydxWalletListViewController: HostingViewController<PlatformView, 
 
     override public func arrive(to request: RoutingRequest?, animated: Bool) -> Bool {
         if request?.path == "/onboard/wallets" {
+            let presenter = presenter as? dydxWalletListViewPresenterProtocol
+            presenter?.mobileOnly = (request?.params?["mobileOnly"] as? String) == "true"
             presenter?.viewModel?.onScrollViewCreated = { [weak self] scrollView in
                 self?.scrollView = scrollView
             }
@@ -45,9 +47,17 @@ private class dydxWalletListViewController: HostingViewController<PlatformView, 
 
 private protocol dydxWalletListViewPresenterProtocol: HostedViewPresenterProtocol {
     var viewModel: dydxWalletListViewModel? { get }
+    var mobileOnly: Bool { get set }
 }
 
 private class dydxWalletListViewPresenter: HostedViewPresenter<dydxWalletListViewModel>, dydxWalletListViewPresenterProtocol {
+
+    var mobileOnly: Bool = false {
+        didSet {
+            updateWallets()
+        }
+    }
+
     private var desktopSyncViewModel: dydxSyncDesktopViewModel = {
         let viewModel = dydxSyncDesktopViewModel()
         viewModel.onTap = {
@@ -108,6 +118,10 @@ private class dydxWalletListViewPresenter: HostedViewPresenter<dydxWalletListVie
         }
 
         let debugScan = UIDevice.current.isSimulator ? [debugScanViewModel] : []
-        viewModel?.items = [desktopSyncViewModel] + debugScan + installedWalletViewModels + uninstalledWalletViewModels
+        if mobileOnly {
+            viewModel?.items = installedWalletViewModels + uninstalledWalletViewModels
+        } else {
+            viewModel?.items = [desktopSyncViewModel] + debugScan + installedWalletViewModels + uninstalledWalletViewModels
+        }
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileButtonsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileButtonsViewPresenter.swift
@@ -43,9 +43,8 @@ class dydxProfileButtonsViewPresenter: HostedViewPresenter<dydxProfileButtonsVie
                 .map(\.currentWallet)
                 .prefix(1)
                 .sink { currentWallet in
-                    if let ethereumAddress = currentWallet?.ethereumAddress {
-                        Router.shared?.navigate(to: RoutingRequest(path: "/action/wallet/disconnect", params: ["ethereumAddress": ethereumAddress]), animated: true, completion: nil)
-                    }
+                    let ethereumAddress = currentWallet?.ethereumAddress ?? ""
+                    Router.shared?.navigate(to: RoutingRequest(path: "/action/wallet/disconnect", params: ["ethereumAddress": ethereumAddress]), animated: true, completion: nil)
                 }
                 .store(in: &self.subscriptions)
         }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Deposit/dydxTransferDepositViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Deposit/dydxTransferDepositViewPresenter.swift
@@ -70,6 +70,12 @@ class dydxTransferDepositViewPresenter: HostedViewPresenter<dydxTransferDepositV
             }
          }
 
+        viewModel.connectWalletAction = {
+            let request = RoutingRequest(path: "/onboard/wallets",
+                                         params: ["mobileOnly": "true"])
+            Router.shared?.navigate(to: request, animated: true, completion: nil)
+        }
+
         self.viewModel = viewModel
 
         attachChildren(workers: childPresenters)
@@ -108,16 +114,19 @@ class dydxTransferDepositViewPresenter: HostedViewPresenter<dydxTransferDepositV
                 AbacusStateManager.shared.state.currentWallet
                     .map(\.?.ethereumAddress)
                     .removeDuplicates()
-            ).sink { [weak self] (resources: TransferInputResources?, chain: String?, tokenAddress: String?, walletAddress: String?) in
+            ).sink { [weak self] (resources: TransferInputResources?, chain: String?, tokenAddress: String?, ethereumAddress: String?) in
                 if let tokenAddress = tokenAddress,
-                   let walletAddress = walletAddress,
+                   let walletAddress = ethereumAddress,
+                   walletAddress.starts(with: "dydx") == false,
                    let chain = chain,
                    let chainRpc = resources?.chainResources?[chain]?.rpc,
                    let tokenResource = resources?.tokenResources?[tokenAddress],
                    let tokenSymbol = tokenResource.symbol,
                    let tokenDecimals = tokenResource.decimals {
+                    self?.viewModel?.showConnectWallet = false
                     self?.fetchTokenAmount(chainRpc: chainRpc, tokenSymbol: tokenSymbol, tokenAddress: tokenAddress, tokenDecimals: tokenDecimals.intValue, walletAddress: walletAddress)
                 } else {
+                    self?.viewModel?.showConnectWallet = true
                     self?.ethereumInteractor = nil
                 }
             }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Wallet/Wallets2ViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Wallet/Wallets2ViewBuilder.swift
@@ -87,7 +87,7 @@ private class Wallets2ViewPresenter: HostedViewPresenter<Wallets2ViewModel> {
     private func updateWalletState(walletState: dydxWalletState) {
         viewModel?.walletConnections = walletState.wallets.map { wallet in
             let viewModel = WalletConnectionViewModel()
-            viewModel.walletAddress = wallet.ethereumAddress
+            viewModel.walletAddress = wallet.ethereumAddress ?? wallet.cosmoAddress
             viewModel.selected = wallet == walletState.currentWallet
             viewModel.onTap = {
                 if let cosmoAddress = wallet.cosmoAddress, let mnemonic = wallet.mnemonic {
@@ -99,10 +99,11 @@ private class Wallets2ViewPresenter: HostedViewPresenter<Wallets2ViewModel> {
             }
 
             viewModel.openInEtherscanTapped = {
-                let ethereumAddress = wallet.ethereumAddress
-                let urlString = "https://etherscan.io/address/\(ethereumAddress)"
-                if let url = URL(string: urlString), URLHandler.shared?.canOpenURL(url) ?? false {
-                    URLHandler.shared?.open(url, completionHandler: nil)
+                if let ethereumAddress = wallet.ethereumAddress {
+                    let urlString = "https://etherscan.io/address/\(ethereumAddress)"
+                    if let url = URL(string: urlString), URLHandler.shared?.canOpenURL(url) ?? false {
+                        URLHandler.shared?.open(url, completionHandler: nil)
+                    }
                 }
             }
 

--- a/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
@@ -18,11 +18,7 @@ public final class AbacusState {
     public var onboarded: AnyPublisher<Bool, Never> {
         walletState
             .map { walletState in
-                if let currentWallet = walletState.currentWallet,
-                   currentWallet.ethereumAddress.length > 0 {
-                    return (currentWallet.cosmoAddress?.length ?? 0) > 0
-                }
-                return false
+                (walletState.currentWallet?.cosmoAddress?.length ?? 0) > 0
             }
             .removeDuplicates()
             .share()

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -218,7 +218,7 @@ public final class AbacusStateManager: NSObject {
         asyncStateManager.accountAddress = ethereumAddress
     }
 
-    public func setV4(ethereumAddress: String, walletId: String?, cosmoAddress: String, mnemonic: String) {
+    public func setV4(ethereumAddress: String?, walletId: String?, cosmoAddress: String, mnemonic: String) {
         CosmoJavascript.shared.connectWallet(mnemonic: mnemonic) { [weak self] _ in
             if let self = self {
                 let wallet = dydxWalletInstance.V4(ethereumAddress: ethereumAddress, walletId: walletId, cosmoAddress: cosmoAddress, mnemonic: mnemonic)

--- a/dydx/dydxStateManager/dydxStateManager/ClientStates/Wallets/dydxWalletState.swift
+++ b/dydx/dydxStateManager/dydxStateManager/ClientStates/Wallets/dydxWalletState.swift
@@ -59,7 +59,7 @@ public struct dydxWalletState: Codable, Equatable {
 }
 
 public struct dydxWalletInstance: Codable, Equatable {
-    public let ethereumAddress: String
+    public let ethereumAddress: String?
     public let walletId: String?
 
     // V4
@@ -72,15 +72,15 @@ public struct dydxWalletInstance: Codable, Equatable {
     public var secret: String?
     public var passPhrase: String?
 
-    static func V4(ethereumAddress: String, walletId: String?, cosmoAddress: String, mnemonic: String) -> Self {
+    static func V4(ethereumAddress: String?, walletId: String?, cosmoAddress: String, mnemonic: String) -> Self {
         Self.init(ethereumAddress: ethereumAddress, walletId: walletId, cosmoAddress: cosmoAddress, mnemonic: mnemonic)
     }
 
-    static func V3(ethereumAddress: String, walletId: String?, apiKey: String, secret: String, passPhrase: String) -> Self {
+    static func V3(ethereumAddress: String?, walletId: String?, apiKey: String, secret: String, passPhrase: String) -> Self {
         Self.init(ethereumAddress: ethereumAddress, walletId: walletId, apiKey: apiKey, secret: secret, passPhrase: passPhrase)
     }
 
-    private init(ethereumAddress: String, walletId: String?, cosmoAddress: String? = nil, mnemonic: String? = nil, subaccountNumber: String? = nil, apiKey: String? = nil, secret: String? = nil, passPhrase: String? = nil) {
+    private init(ethereumAddress: String?, walletId: String?, cosmoAddress: String? = nil, mnemonic: String? = nil, subaccountNumber: String? = nil, apiKey: String? = nil, secret: String? = nil, passPhrase: String? = nil) {
         self.ethereumAddress = ethereumAddress
         self.walletId = walletId
         self.cosmoAddress = cosmoAddress

--- a/dydx/dydxStateManager/dydxStateManager/Transactions/Deposit/DepositTransaction.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Transactions/Deposit/DepositTransaction.swift
@@ -18,15 +18,16 @@ public struct DepositTransaction: AsyncStep {
     private let depositTransactionV4: DepositTransactionV4?
 
     public let transferInput: TransferInput
-    public let walletAddress: String
+    public let walletAddress: String?
     public let walletId: String?
 
-    public init(transferInput: TransferInput, walletAddress: String, walletId: String?) {
+    public init(transferInput: TransferInput, walletAddress: String?, walletId: String?) {
         self.transferInput = transferInput
         self.walletAddress = walletAddress
         self.walletId = walletId
 
-        if let chain = transferInput.chain, let token = transferInput.token,
+        if let walletAddress = walletAddress,
+            let chain = transferInput.chain, let token = transferInput.token,
            let chainRpc = transferInput.resources?.chainResources?[chain]?.rpc,
            let tokenAddress = transferInput.resources?.tokenResources?[token]?.address {
             depositTransactionV4 = DepositTransactionV4(transferInput: transferInput,

--- a/dydx/dydxViews/dydxViews/_v4/Onboarding/ScanInstructions/dydxOnboardScanInstructionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Onboarding/ScanInstructions/dydxOnboardScanInstructionsView.swift
@@ -49,7 +49,7 @@ public class dydxOnboardScanInstructionsViewModel: PlatformViewModel {
                 let buttonContent =
                     Text(DataLocalizer.localize(path: "APP.ONBOARDING.OPEN_QR_CODE_NEXT"))
                         .wrappedViewModel
-                PlatformButtonViewModel(content: buttonContent, type: .defaultType) { [weak self] in
+                PlatformButtonViewModel(content: buttonContent, type: .defaultType(fillWidth: true)) { [weak self] in
                     self?.ctaAction?()
                 }
                 .createView(parentStyle: style)

--- a/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxRewardsHistoryView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxRewardsHistoryView.swift
@@ -89,7 +89,7 @@ public class dydxRewardsHistoryViewModel: dydxTitledCardViewModel {
             }
             .wrappedInAnyView()
         },
-                                type: .defaultType,
+                                type: .defaultType(fillWidth: true),
                                 state: .secondary,
                                 action: {
             withAnimation { [weak self] in

--- a/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxRewardsLaunchIncentivesView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxRewardsLaunchIncentivesView.swift
@@ -91,7 +91,7 @@ public class dydxRewardsLaunchIncentivesViewModel: PlatformViewModel {
             }
             .wrappedInAnyView()
         }
-        return PlatformButtonViewModel(content: content, type: .defaultType, state: .secondary, action: self.aboutAction ?? {})
+        return PlatformButtonViewModel(content: content, type: .defaultType(fillWidth: true), state: .secondary, action: self.aboutAction ?? {})
             .createView(parentStyle: parentStyle)
     }
 
@@ -106,7 +106,7 @@ public class dydxRewardsLaunchIncentivesViewModel: PlatformViewModel {
             }
             .wrappedInAnyView()
         }
-        return PlatformButtonViewModel(content: content, type: .defaultType, state: .primary, action: self.leaderboardAction ?? {})
+        return PlatformButtonViewModel(content: content, type: .defaultType(fillWidth: true), state: .primary, action: self.leaderboardAction ?? {})
             .createView(parentStyle: parentStyle)
     }
 

--- a/dydx/dydxViews/dydxViews/_v4/Transfer/Deposit/dydxTransferDepositView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Transfer/Deposit/dydxTransferDepositView.swift
@@ -19,6 +19,8 @@ public class dydxTransferDepositViewModel: PlatformViewModel {
                                inputType: .decimalDigits)
     @Published public var ctaButton: dydxTradeInputCtaButtonViewModel? = dydxTradeInputCtaButtonViewModel()
     @Published public var validationViewModel: dydxValidationViewModel? = dydxValidationViewModel()
+    @Published public var showConnectWallet = false
+    @Published public var connectWalletAction: (() -> Void)?
 
     public init() { }
 
@@ -40,9 +42,23 @@ public class dydxTransferDepositViewModel: PlatformViewModel {
                 VStack {
                     Group {
                         VStack(spacing: 12) {
-                            self.chainsComboBox?.createView(parentStyle: style)
-                            self.tokensComboBox?.createView(parentStyle: style)
-                            self.amountBox?.createView(parentStyle: style)
+                            if self.showConnectWallet {
+                                HStack(spacing: 8) {
+                                    Text(DataLocalizer.localize(path: "APP.V4_DEPOSIT.MOBILE_WALLET_REQUIRED"))
+                                        .themeFont(fontSize: .medium)
+
+                                    let content = Text(DataLocalizer.localize(path: "APP.GENERAL.CONNECT_WALLET")).lineLimit(1).wrappedViewModel
+                                    PlatformButtonViewModel(content: content,
+                                                            type: .defaultType(fillWidth: false)) { [weak self] in
+                                        self?.connectWalletAction?()
+                                    }
+                                    .createView(parentStyle: style)
+                                }
+                            } else {
+                                self.chainsComboBox?.createView(parentStyle: style)
+                                self.tokensComboBox?.createView(parentStyle: style)
+                                self.amountBox?.createView(parentStyle: style)
+                            }
                         }
                     }
 

--- a/dydx/dydxViews/dydxViews/_v4/Wallet/WalletConnectionView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Wallet/WalletConnectionView.swift
@@ -48,7 +48,8 @@ public class WalletConnectionViewModel: PlatformViewModel {
                                                        templateColor: self?.templateColor ?? .textTertiary)
                         .createView(parentStyle: style)
 
-                    let addressText = Text(self?.walletAddress ?? "")
+                    let walletAddress = self?.walletAddress ?? ""
+                    let addressText = Text(walletAddress)
                         .lineLimit(1)
                         .truncationMode(.middle)
                         .themeFont(fontSize: .medium)
@@ -91,7 +92,8 @@ public class WalletConnectionViewModel: PlatformViewModel {
 
                     let main = VStack(alignment: .leading) {
                         addressText
-                        if self?.selected == true {
+                        if self?.selected == true &&
+                            walletAddress.isNotEmpty && walletAddress.starts(with: "dydx") == false {
                             HStack(spacing: 10) {
                                 blockExplorerButton
                                 exportPhraseButton

--- a/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4Tests.xcscheme
+++ b/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4Tests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3112F474216BBF8600708927"
+               BuildableName = "dydxV4Tests.xctest"
+               BlueprintName = "dydxV4Tests"
+               ReferencedContainer = "container:dydxV4.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4UITests.xcscheme
+++ b/dydxV4/dydxV4.xcodeproj/xcshareddata/xcschemes/dydxV4UITests.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "# Type a script or drag a script file from your workspace to insert its path.&#10;&#10;&#10;// https://www.browserstack.com/docs/app-automate/xcuitest/build-export-testsuite&#10;&#10;echo aaaaa&#10;echo $TARGET_BUILD_DIR&#10;BUILD_DIR=$TARGET_BUILD_DIR/../..&#10;cd $BUILD_DIR&#10;&#10;cp -r dydxV4UITests-Runner.app /tmp/&#10;cd /tmp&#10;zip --symlinks -r dydxV4UITests.zip dydxV4UITests-Runner.app&#10;&#10;&#10;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "02DA0AF62B57609100BFA975"
+                     BuildableName = "dydxV4UITests.xctest"
+                     BlueprintName = "dydxV4UITests"
+                     ReferencedContainer = "container:dydxV4.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02DA0AF62B57609100BFA975"
+               BuildableName = "dydxV4UITests.xctest"
+               BlueprintName = "dydxV4UITests"
+               ReferencedContainer = "container:dydxV4.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3112F45E216BBF8400708927"
+            BuildableName = "dydxV4.app"
+            BlueprintName = "dydxV4"
+            ReferencedContainer = "container:dydxV4.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION

<br/>

## Description / Intuition
Show "Connect Wallet" button on the deposit screen when the user onboarded via "scan desktop". In this case, the app won't have a wallet type and eth address that are needed to initiate the deposit.  

A mobileOnly param has been added to the wallet_list request.  If it's set to "true", the list will only show the mobile wallets (and skipping "Scan Desktop")



<br/>

## Before/After Screenshots or Videos

https://github.com/dydxprotocol/v4-native-ios/assets/102453770/95b2838b-a7c0-4203-bce8-baddb82e3ff3

<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
