### PR TITLE
MOB-346 : pre-select last selected market for trade input if no market is specified

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters.xcodeproj/project.pbxproj
+++ b/dydx/dydxPresenters/dydxPresenters.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 		2741E3732A689740000FA190 /* dydxDirectionColorPreferenceViewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2741E3722A689740000FA190 /* dydxDirectionColorPreferenceViewBuilder.swift */; };
 		2749F8FF2B853B8700D6BA16 /* dydxRewardsLaunchIncentivesPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2749F8FE2B853B8700D6BA16 /* dydxRewardsLaunchIncentivesPresenter.swift */; };
 		276908FF2AAFB22F0075B2D6 /* dydxPortfolioTransfersViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 276908FE2AAFB22F0075B2D6 /* dydxPortfolioTransfersViewPresenter.swift */; };
+		277987512BA33F15006DC5CD /* dydxSelectedMarketStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277987502BA33F15006DC5CD /* dydxSelectedMarketStore.swift */; };
 		277E8FC92B1E576B005CCBCB /* dydxProfileRewardsViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277E8FC82B1E576B005CCBCB /* dydxProfileRewardsViewPresenter.swift */; };
 		277E90152B1EA0E3005CCBCB /* dydxTradingRewardsViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277E90142B1EA0E3005CCBCB /* dydxTradingRewardsViewPresenter.swift */; };
 		277E90192B1EA3C3005CCBCB /* dydxRewardsSummaryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 277E90182B1EA3C3005CCBCB /* dydxRewardsSummaryPresenter.swift */; };
@@ -475,6 +476,7 @@
 		2741E3722A689740000FA190 /* dydxDirectionColorPreferenceViewBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = dydxDirectionColorPreferenceViewBuilder.swift; sourceTree = "<group>"; };
 		2749F8FE2B853B8700D6BA16 /* dydxRewardsLaunchIncentivesPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxRewardsLaunchIncentivesPresenter.swift; sourceTree = "<group>"; };
 		276908FE2AAFB22F0075B2D6 /* dydxPortfolioTransfersViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxPortfolioTransfersViewPresenter.swift; sourceTree = "<group>"; };
+		277987502BA33F15006DC5CD /* dydxSelectedMarketStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxSelectedMarketStore.swift; sourceTree = "<group>"; };
 		277E8FC82B1E576B005CCBCB /* dydxProfileRewardsViewPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = dydxProfileRewardsViewPresenter.swift; sourceTree = "<group>"; };
 		277E90142B1EA0E3005CCBCB /* dydxTradingRewardsViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxTradingRewardsViewPresenter.swift; sourceTree = "<group>"; };
 		277E90182B1EA3C3005CCBCB /* dydxRewardsSummaryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxRewardsSummaryPresenter.swift; sourceTree = "<group>"; };
@@ -1126,6 +1128,7 @@
 		02B8419F28EF68E400C4D25B /* MarketInfo */ = {
 			isa = PBXGroup;
 			children = (
+				277987502BA33F15006DC5CD /* dydxSelectedMarketStore.swift */,
 				0274B34328F113FD005AF69E /* Components */,
 				02B841B128EF6C6400C4D25B /* dydxMarketInfoViewBuilder.swift */,
 			);
@@ -1839,6 +1842,7 @@
 				02F700FE29EA0FD9004DEB5E /* dydxReceiptPresenter.swift in Sources */,
 				027E1EF829CA27CD0098666F /* dydxSettingsLandingViewBuilder.swift in Sources */,
 				020DBF1E29E092C00068AAA6 /* dydxTransferDepositViewPresenter.swift in Sources */,
+				277987512BA33F15006DC5CD /* dydxSelectedMarketStore.swift in Sources */,
 				0238FB72296C4438002E1C1A /* HistoricalPNLDataPoint.swift in Sources */,
 				021B68B12AD9B86600C5C3BF /* dydxSecurityViewPresenter.swift in Sources */,
 				024B43A229812DC700E35D54 /* dydxValidationViewPresenter.swift in Sources */,

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/dydxMarketInfoViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/dydxMarketInfoViewBuilder.swift
@@ -28,7 +28,7 @@ public class dydxMarketInfoViewBuilder: NSObject, ObjectBuilderProtocol {
 private class dydxMarketInfoViewController: HostingViewController<PlatformView, dydxMarketInfoViewModel> {
     override public func arrive(to request: RoutingRequest?, animated: Bool) -> Bool {
         if request?.path == "/trade" || request?.path == "/market", let presenter = presenter as? dydxMarketInfoViewPresenter {
-            presenter.marketId = request?.params?["market"] as? String ?? "ETH-USD"
+            presenter.marketId = request?.params?["market"] as? String ?? dydxSelectedMarketsStore.shared.lastSelectedMarket
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 if request?.path == "/trade" {
                     Router.shared?.navigate(to: RoutingRequest(path: "/trade/input", params: ["full": "true"]), animated: true, completion: nil)
@@ -122,6 +122,8 @@ private class dydxMarketInfoViewPresenter: HostedViewPresenter<dydxMarketInfoVie
     override func start() {
         super.start()
 
+        guard let marketId = marketId else { return }
+        dydxSelectedMarketsStore.shared.lastSelectedMarket = marketId
         AbacusStateManager.shared.setMarket(market: marketId)
 
         $marketId

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/dydxMarketInfoViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/dydxMarketInfoViewBuilder.swift
@@ -28,7 +28,9 @@ public class dydxMarketInfoViewBuilder: NSObject, ObjectBuilderProtocol {
 private class dydxMarketInfoViewController: HostingViewController<PlatformView, dydxMarketInfoViewModel> {
     override public func arrive(to request: RoutingRequest?, animated: Bool) -> Bool {
         if request?.path == "/trade" || request?.path == "/market", let presenter = presenter as? dydxMarketInfoViewPresenter {
-            presenter.marketId = request?.params?["market"] as? String ?? dydxSelectedMarketsStore.shared.lastSelectedMarket
+            let selectedMarketId = request?.params?["market"] as? String ?? dydxSelectedMarketsStore.shared.lastSelectedMarket
+            dydxSelectedMarketsStore.shared.lastSelectedMarket = selectedMarketId
+            presenter.marketId = selectedMarketId
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 if request?.path == "/trade" {
                     Router.shared?.navigate(to: RoutingRequest(path: "/trade/input", params: ["full": "true"]), animated: true, completion: nil)
@@ -123,7 +125,6 @@ private class dydxMarketInfoViewPresenter: HostedViewPresenter<dydxMarketInfoVie
         super.start()
 
         guard let marketId = marketId else { return }
-        dydxSelectedMarketsStore.shared.lastSelectedMarket = marketId
         AbacusStateManager.shared.setMarket(market: marketId)
 
         $marketId

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/dydxSelectedMarketStore.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/dydxSelectedMarketStore.swift
@@ -1,0 +1,19 @@
+//
+//  dydxSelectedMarketsStore.swift
+//  dydxPresenters
+//
+//  Created by Michael Maguire on 3/14/24.
+//
+
+import Foundation
+import Utilities
+
+final class dydxSelectedMarketsStore {
+    private let storeKey = "last_selected_market"
+    static let shared = dydxSelectedMarketsStore()
+
+    var lastSelectedMarket: String {
+        get { SettingsStore.shared?.value(forKey: storeKey) as? String ?? "ETH-USD" }
+        set { SettingsStore.shared?.setValue(newValue, forKey: storeKey) }
+    }
+}


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-346 : pre-select last selected market for trade input if no market is specified](https://linear.app/dydx/issue/MOB-346/pre-select-last-selected-market-for-trade-input-if-no-market-is)



<br/>

## Description / Intuition
- previously, the trade button always first routes to ETH. Now, we bring the user to the last displayed market




<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/8cf0ab2b-cef1-43ea-b059-f51d3a404042"> |


<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
