### PR TITLE
MOB-333 Withdrawal error message "insufficient balance" but it seems …

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
@@ -230,30 +230,30 @@ class dydxTransferInputCtaButtonViewPresenter: HostedViewPresenter<dydxTradeInpu
                       let amount = transferInput.size?.usdcSize, (self.parser.asDecimal(amount)?.doubleValue ?? 0) > 0.0 else {
                     return
                 }
-                let gasFee = transferInput.summary?.gasFee?.doubleValue ?? 0
-                let usdcBalanceInWallet = usdcBalanceInWallet ?? 0
-                if usdcBalanceInWallet >= gasFee {
-                    if transferInput.isCctp {
-                        AbacusStateManager.shared.commitCCTPWithdraw { [weak self] success, error, result in
-                            if success {
-                                self?.postTransaction(result: result, transferInput: transferInput)
-                            } else {
-                                ErrorInfo.shared?.info(title: DataLocalizer.localize(path: "APP.GENERAL.ERROR"),
-                                                       message: error?.localizedDescription,
-                                                       type: .error,
-                                                       error: nil, time: nil)
-                            }
-                            self?.viewModel?.ctaButtonState = .enabled(DataLocalizer.localize(path: "APP.GENERAL.CONFIRM_WITHDRAW"))
+                if transferInput.isCctp {
+                    AbacusStateManager.shared.commitCCTPWithdraw { [weak self] success, error, result in
+                        if success {
+                            self?.postTransaction(result: result, transferInput: transferInput)
+                        } else {
+                            ErrorInfo.shared?.info(title: DataLocalizer.localize(path: "APP.GENERAL.ERROR"),
+                                                   message: error?.localizedDescription,
+                                                   type: .error,
+                                                   error: nil, time: nil)
                         }
-                    } else {
+                        self?.viewModel?.ctaButtonState = .enabled(DataLocalizer.localize(path: "APP.GENERAL.CONFIRM_WITHDRAW"))
+                    }
+                } else {
+                    let gasFee = transferInput.summary?.gasFee?.doubleValue ?? 0
+                    let usdcBalanceInWallet = usdcBalanceInWallet ?? 0
+                    if usdcBalanceInWallet >= gasFee {
                         CosmoJavascript.shared.withdrawToIBC(subaccount: Int(selectedSubaccount.subaccountNumber), amount: amount, payload: data) { [weak self] result in
                             self?.postTransaction(result: result, transferInput: transferInput)
                             self?.viewModel?.ctaButtonState = .enabled(DataLocalizer.localize(path: "APP.GENERAL.CONFIRM_WITHDRAW"))
                         }
+                    } else {
+                        self.showNoGas()
+                        self.viewModel?.ctaButtonState = .enabled(DataLocalizer.localize(path: "APP.GENERAL.CONFIRM_WITHDRAW"))
                     }
-                } else {
-                    self.showNoGas()
-                    self.viewModel?.ctaButtonState = .enabled(DataLocalizer.localize(path: "APP.GENERAL.CONFIRM_WITHDRAW"))
                 }
             }
         }


### PR DESCRIPTION


## Description / Intuition
For CCTP withdrawals, we shouldn't use the gas estimate from Squid to block the user.  The logic only applies to non-CCTP transactions.





<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
