### PR TITLE
update share action class name to fix share action routing

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Actions/dydxShareActionBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Actions/dydxShareActionBuilder.swift
@@ -11,7 +11,7 @@ import Utilities
 import UIToolkits
 import dydxStateManager
 
-public class ShareActionBuilder: NSObject, ObjectBuilderProtocol {
+public class dydxShareActionBuilder: NSObject, ObjectBuilderProtocol {
     public func build<T>() -> T? {
         let action = dydxShareAction()
         return action as? T


### PR DESCRIPTION
## Description / Intuition
- bug was discovered during testing DoS's 1.2.0 app
- follow up to https://github.com/dydxprotocol/v4-native-ios/pull/98

issue was that name of dydxShareAction was changed. In routing_swift.json, we have:
```
                "/action/share": {
                    "destination":"dydxPresenters.dydxShareActionBuilder"
                },
```

but the claas name (before this PR) was ShareActionBuilder. Class name needs to match routing class name


<video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/46326b53-2635-4cc3-ab6a-5e421d094d9e">


