### PR TITLE
MOB-386 Fix Subaccount transfer for France

### DIFF
--- a/dydx/dydxFormatter/dydxFormatter.xcodeproj/xcshareddata/xcschemes/dydxFormatterTests.xcscheme
+++ b/dydx/dydxFormatter/dydxFormatter.xcodeproj/xcshareddata/xcschemes/dydxFormatterTests.xcscheme
@@ -14,7 +14,8 @@
       shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "02841E3229AD6E5500C0E7CC"

--- a/dydx/dydxFormatter/dydxFormatter.xcodeproj/xcshareddata/xcschemes/dydxFormatterTests.xcscheme
+++ b/dydx/dydxFormatter/dydxFormatter.xcodeproj/xcshareddata/xcschemes/dydxFormatterTests.xcscheme
@@ -14,8 +14,7 @@
       shouldAutocreateTestPlan = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "02841E3229AD6E5500C0E7CC"

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -388,6 +388,13 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
     }
 
     /*
+     xxxxx.yyyyy
+     */
+    public func decimalRaw(number: NSNumber?, digits: Int) -> String? {
+        return raw(number: number, digits: digits)?.replacingOccurrences(of: ",", with: ".")
+    }
+
+    /*
      xxxxxx,yyyyy or xxxxx.yyyyy
      */
     public func raw(number: NSNumber?, digits: Int) -> String? {

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -383,14 +383,14 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
     /*
      xxxxx.yyyyy
      */
-    public func decimalRaw(number: NSNumber?, size: String?) -> String? {
+    public func decimalLocalAgnostic(number: NSNumber?, size: String?) -> String? {
         raw(number: number, size: size, locale: Locale(identifier: "en-US"))
     }
 
     /*
      xxxxx.yyyyy
      */
-    public func decimalRaw(number: NSNumber?, digits: Int) -> String? {
+    public func decimalLocalAgnostic(number: NSNumber?, digits: Int) -> String? {
         raw(number: number, digits: digits, locale: Locale(identifier: "en-US"))
     }
 

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -390,7 +390,7 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
     /*
      xxxxx.yyyyy
      */
-    public func decimalLocalAgnostic(number: NSNumber?, digits: Int) -> String? {
+    public func decimalLocaleAgnostic(number: NSNumber?, digits: Int) -> String? {
         raw(number: number, digits: digits, locale: Locale(identifier: "en-US"))
     }
 

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -460,12 +460,10 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
 
     private func rounded(number: NSNumber, digits: Int) -> NSNumber {
         if number.doubleValue.isFinite {
-            let double = number.doubleValue
-             if digits >= 0 {
-                let divideBy = pow(10, UInt(digits))
-                let roundedUp = Int(double / Double(divideBy)) * divideBy
-                return NSNumber(value: roundedUp)
+            if digits >= 0 {
+                return number
             } else {
+                let double = number.doubleValue
                 let reversed = digits * -1
                 let divideBy = pow(10, UInt(reversed))
                 let roundedUp = Int(double / Double(divideBy)) * divideBy

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -383,7 +383,7 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
     /*
      xxxxx.yyyyy
      */
-    public func decimalLocalAgnostic(number: NSNumber?, size: String?) -> String? {
+    public func decimalLocaleAgnostic(number: NSNumber?, size: String?) -> String? {
         raw(number: number, size: size, locale: Locale(identifier: "en-US"))
     }
 
@@ -405,9 +405,9 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
                     rawFormatter.minimumFractionDigits = max(digits, 0)
                     rawFormatter.maximumFractionDigits = max(digits, 0)
                     rawFormatter.roundingMode = .halfUp
-                   
+
                     let formatted = rawFormatter.string(from: number)
-                    
+
                     // need to special case for negative 0, see dydxFormatter tests. E.g. "-$0.001" should go to "$0.00"
                     if let formatted = formatted, rawFormatter.number(from: formatted) == 0 {
                         return rawFormatter.string(from: 0)

--- a/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
+++ b/dydx/dydxFormatter/dydxFormatter/dydxFormatter.swift
@@ -374,7 +374,7 @@ public final class dydxFormatter: NSObject, SingletonProtocol {
             let size = size ?? "0.01"
             let digits = digits(size: size)
             let rounded = rounded(number: number, digits: digits)
-            return raw(number: rounded, digits: digits)
+            return raw(number: rounded, digits: digits, locale: locale)
         } else {
             return nil
         }

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -18,7 +18,7 @@ final class dydxFormatterTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
     
-    func testDecimalLocalAgnostic() {
+    func testDecimalLocaleAgnostic() {
         struct TestCase {
             let number: NSNumber
             let digits: Int
@@ -36,7 +36,7 @@ final class dydxFormatterTests: XCTestCase {
         ]
 
         for testCase in testCases {
-            let formatted = dydxFormatter.shared.decimalLocalAgnostic(number: testCase.number, digits: testCase.digits)
+            let formatted = dydxFormatter.shared.decimalLocaleAgnostic(number: testCase.number, digits: testCase.digits)
             XCTAssertEqual(formatted, testCase.expected, "Test case: \(testCase)")
         }
     }

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -17,7 +17,7 @@ final class dydxFormatterTests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-    
+
     func testDecimalLocaleAgnostic() {
         struct TestCase {
             let number: NSNumber
@@ -32,7 +32,7 @@ final class dydxFormatterTests: XCTestCase {
             .init(number: -0.001, digits: 2, expected: "0.00"),
             .init(number: 0.001, digits: 2, expected: "0.00"),
             .init(number: -0.005, digits: 2, expected: "-0.01"),
-            .init(number: -0.0051, digits: 2, expected: "-0.01"),
+            .init(number: -0.0051, digits: 2, expected: "-0.01")
         ]
 
         for testCase in testCases {
@@ -40,7 +40,7 @@ final class dydxFormatterTests: XCTestCase {
             XCTAssertEqual(formatted, testCase.expected, "Test case: \(testCase)")
         }
     }
-    
+
     func testRaw() {
         struct TestCase {
             let number: NSNumber
@@ -57,7 +57,7 @@ final class dydxFormatterTests: XCTestCase {
             .init(number: 0.001, digits: 2, expected: "0.00"),
             .init(number: -0.005, digits: 2, expected: "-0.01"),
             .init(number: -0.0051, digits: 2, expected: "-0.01"),
-            .init(number: 1123345.123, digits: 2, expected: "1123345,12", locale: Locale(identifier: "fr_FR")),
+            .init(number: 1123345.123, digits: 2, expected: "1123345,12", locale: Locale(identifier: "fr_FR"))
         ]
 
         for testCase in testCases {
@@ -65,7 +65,7 @@ final class dydxFormatterTests: XCTestCase {
             XCTAssertEqual(formatted, testCase.expected, "Test case: \(testCase)")
         }
     }
-    
+
     func testDollarFormatting() throws {
         struct TestCase {
             let number: Double

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -18,6 +18,32 @@ final class dydxFormatterTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
 
+    
+    func testDecimalRaw() {
+        struct TestCase {
+            let number: NSNumber
+            let digits: Int
+            let expected: String
+            var locale: Locale = Locale.current
+        }
+
+        let testCases: [TestCase] = [
+            .init(number: 1, digits: 2, expected: "1.00"),
+            .init(number: -0.001, digits: 0, expected: "0"),
+            .init(number: -0.001, digits: 3, expected: "-0.001"),
+            .init(number: -0.001, digits: 2, expected: "0.00"),
+            .init(number: 0.001, digits: 2, expected: "0.00"),
+            .init(number: -0.005, digits: 2, expected: "-0.01"),
+            .init(number: -0.0051, digits: 2, expected: "-0.01"),
+            .init(number: 1123345.123, digits: 2, expected: "1123345.12", locale: Locale(identifier: "fr_FR")),
+        ]
+
+        for testCase in testCases {
+            let formatted = dydxFormatter.shared.decimalRaw(number: testCase.number, digits: testCase.digits)
+            XCTAssertEqual(formatted, testCase.expected, "Test case: \(testCase)")
+        }
+    }
+    
     func testDollarFormatting() throws {
         struct TestCase {
             let number: Double

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -17,14 +17,12 @@ final class dydxFormatterTests: XCTestCase {
     override func tearDownWithError() throws {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
     
     func testDecimalRaw() {
         struct TestCase {
             let number: NSNumber
             let digits: Int
             let expected: String
-            var locale: Locale = Locale.current
         }
 
         let testCases: [TestCase] = [
@@ -35,11 +33,35 @@ final class dydxFormatterTests: XCTestCase {
             .init(number: 0.001, digits: 2, expected: "0.00"),
             .init(number: -0.005, digits: 2, expected: "-0.01"),
             .init(number: -0.0051, digits: 2, expected: "-0.01"),
-            .init(number: 1123345.123, digits: 2, expected: "1123345.12", locale: Locale(identifier: "fr_FR")),
         ]
 
         for testCase in testCases {
-            let formatted = dydxFormatter.shared.decimalRaw(number: testCase.number, digits: testCase.digits)
+            let formatted = dydxFormatter.shared.decimalLocalAgnostic(number: testCase.number, digits: testCase.digits)
+            XCTAssertEqual(formatted, testCase.expected, "Test case: \(testCase)")
+        }
+    }
+    
+    func testDRaw() {
+        struct TestCase {
+            let number: NSNumber
+            let digits: Int
+            let expected: String
+            var locale: Locale = Locale(identifier: "en_US")
+        }
+
+        let testCases: [TestCase] = [
+            .init(number: 1, digits: 2, expected: "1.00"),
+            .init(number: -0.001, digits: 0, expected: "0"),
+            .init(number: -0.001, digits: 3, expected: "-0.001"),
+            .init(number: -0.001, digits: 2, expected: "0.00"),
+            .init(number: 0.001, digits: 2, expected: "0.00"),
+            .init(number: -0.005, digits: 2, expected: "-0.01"),
+            .init(number: -0.0051, digits: 2, expected: "-0.01"),
+            .init(number: 1123345.123, digits: 2, expected: "1123345,12", locale: Locale(identifier: "fr_FR")),
+        ]
+
+        for testCase in testCases {
+            let formatted = dydxFormatter.shared.raw(number: testCase.number, digits: testCase.digits, locale: testCase.locale)
             XCTAssertEqual(formatted, testCase.expected, "Test case: \(testCase)")
         }
     }

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -41,7 +41,7 @@ final class dydxFormatterTests: XCTestCase {
         }
     }
     
-    func testDRaw() {
+    func testRaw() {
         struct TestCase {
             let number: NSNumber
             let digits: Int

--- a/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
+++ b/dydx/dydxFormatter/dydxFormatterTests/dydxFormatterTests.swift
@@ -18,7 +18,7 @@ final class dydxFormatterTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
     
-    func testDecimalRaw() {
+    func testDecimalLocalAgnostic() {
         struct TestCase {
             let number: NSNumber
             let digits: Int

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -40,8 +40,8 @@ final class dydxTransferSubaccountWorker: BaseWorker {
                     subaccountNumber = 0
                 }
                 let depositAmount = (balance ?? 0) - dydxTransferSubaccountWorker.balanceRetainAmount
-                let amountString = dydxFormatter.shared.decimalLocalAgnostic(number: NSNumber(value: depositAmount),
-                                                                             digits: dydxTokenConstants.usdcTokenDecimal)
+                let amountString = dydxFormatter.shared.decimalLocaleAgnostic(number: NSNumber(value: depositAmount),
+                                                                              digits: dydxTokenConstants.usdcTokenDecimal)
                 if let amountString = amountString {
                     self?.depositToSubaccount(amount: amountString,
                                               subaccount: subaccountNumber,

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -55,7 +55,7 @@ final class dydxTransferSubaccountWorker: BaseWorker {
 
     private func depositToSubaccount(amount: String, subaccount: Int, walletState: dydxWalletState) {
         CosmoJavascript.shared.depositToSubaccount(subaccount: subaccount, amount: amount) { result in
-            let trackingData = [
+            var trackingData = [
                 "amount": "\(amount)",
                 "address": "\(String(describing: walletState.currentWallet?.cosmoAddress))"
             ]
@@ -65,6 +65,9 @@ final class dydxTransferSubaccountWorker: BaseWorker {
                 Tracking.shared?.log(event: "SubaccountDeposit", data: trackingData)
             } else {
                 Console.shared.log("Deposit to subaccount failed")
+                if let resultString = result as? String {
+                    trackingData["error"] = resultString
+                }
                 Tracking.shared?.log(event: "SubaccountDeposit_Failed", data: trackingData)
             }
         }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -40,8 +40,8 @@ final class dydxTransferSubaccountWorker: BaseWorker {
                     subaccountNumber = 0
                 }
                 let depositAmount = (balance ?? 0) - dydxTransferSubaccountWorker.balanceRetainAmount
-                let amountString = dydxFormatter.shared.raw(number: NSNumber(value: depositAmount),
-                                                            digits: dydxTokenConstants.usdcTokenDecimal)
+                let amountString = dydxFormatter.shared.decimalRaw(number: NSNumber(value: depositAmount),
+                                                                   digits: dydxTokenConstants.usdcTokenDecimal)
                 if let amountString = amountString {
                     self?.depositToSubaccount(amount: amountString,
                                               subaccount: subaccountNumber,

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -40,8 +40,8 @@ final class dydxTransferSubaccountWorker: BaseWorker {
                     subaccountNumber = 0
                 }
                 let depositAmount = (balance ?? 0) - dydxTransferSubaccountWorker.balanceRetainAmount
-                let amountString = dydxFormatter.shared.decimalRaw(number: NSNumber(value: depositAmount),
-                                                                   digits: dydxTokenConstants.usdcTokenDecimal)
+                let amountString = dydxFormatter.shared.decimalLocalAgnostic(number: NSNumber(value: depositAmount),
+                                                                             digits: dydxTokenConstants.usdcTokenDecimal)
                 if let amountString = amountString {
                     self?.depositToSubaccount(amount: amountString,
                                               subaccount: subaccountNumber,


### PR DESCRIPTION

<br/>

## Description / Intuition
dydxFormatter.shared.raw() produce "xxx,yyy" for decimal numbers when locale is set to France.  Updated to use dydxFormatter.shared.decimalRaw()

Tested with device locale set to France.

see [bug report](https://dydx-team.slack.com/archives/C065J3L3SH0/p1710764679802259)




<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
