### PR TITLE
MOB-426 : add top receipt area to price triggers panel screen

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
@@ -303,7 +303,7 @@
                     "destination":"dydxPresenters.dydxClosePositionInputViewBuilder",
                     "presentation":"half"
                 },
-                "/trade/take_proft_stop_loss":{
+                "/trade/take_profit_stop_loss":{
                     "destination":"dydxPresenters.dydxTakeProfitStopLossViewBuilder",
                     "presentation":"half"
                 },

--- a/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/MarketInfo/Components/dydxMarketPositionViewPresenter.swift
@@ -32,7 +32,7 @@ class dydxMarketPositionViewPresenter: HostedViewPresenter<dydxMarketPositionVie
         #if DEBUG
         viewModel?.takeProfitStopLossAction = {[weak self] in
             if let assetId = self?.position?.assetId {
-                Router.shared?.navigate(to: RoutingRequest(path: "/trade/take_proft_stop_loss", params: ["marketId": "\(assetId)-USD"]), animated: true, completion: nil)
+                Router.shared?.navigate(to: RoutingRequest(path: "/trade/take_profit_stop_loss", params: ["marketId": "\(assetId)-USD"]), animated: true, completion: nil)
             }
         }
         #endif

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
@@ -9,8 +9,12 @@ import PlatformUI
 import SwiftUI
 import Utilities
 import Introspect
+import dydxFormatter
 
 public class dydxTakeProfitStopLossViewModel: PlatformViewModel {
+
+    @Published public var entryPrice: Double?
+    @Published public var oraclePrice: Double?
 
     public init() {}
 
@@ -19,22 +23,49 @@ public class dydxTakeProfitStopLossViewModel: PlatformViewModel {
         return vm
     }
 
+    private func createHeader() -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(localizerPathKey: "APP.TRIGGERS_MODAL.PRICE_TRIGGERS")
+                .themeFont(fontType: .plus, fontSize: .larger)
+                .themeColor(foreground: .textPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text(localizerPathKey: "APP.TRIGGERS_MODAL.PRICE_TRIGGERS_DESCRIPTION")
+                .themeFont(fontType: .base, fontSize: .small)
+                .themeColor(foreground: .textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func createReceipt() -> some View {
+        VStack(spacing: 12) {
+            createReceiptLine(titleLocalizerPathKey: "APP.TRIGGERS_MODAL.AVG_ENTRY_PRICE", dollarValue: entryPrice)
+            createReceiptLine(titleLocalizerPathKey: "APP.TRADE.ORACLE_PRICE", dollarValue: oraclePrice)
+        }
+        .padding(.all, 12)
+        .themeColor(background: .layer2)
+        .clipShape(.rect(cornerRadius: 8))
+    }
+
+    private func createReceiptLine(titleLocalizerPathKey: String, dollarValue: Double?) -> some View {
+        HStack(alignment: .center, spacing: 0) {
+            Text(localizerPathKey: titleLocalizerPathKey)
+                .themeFont(fontType: .base, fontSize: .small)
+                .themeColor(foreground: .textTertiary)
+            Spacer()
+            Text(dydxFormatter.shared.dollar(number: dollarValue, digits: 2) ?? "")
+                .themeFont(fontType: .number, fontSize: .small)
+                .themeColor(foreground: .textPrimary)
+        }
+    }
+
     override public func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformUI.PlatformView {
         PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] _ in
             guard let self = self else { return AnyView(PlatformView.nilView) }
 
-            let view = VStack {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(localizerPathKey: "APP.TRIGGERS_MODAL.PRICE_TRIGGERS")
-                        .themeFont(fontType: .plus, fontSize: .larger)
-                        .themeColor(foreground: .textPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Text(localizerPathKey: "APP.TRIGGERS_MODAL.PRICE_TRIGGERS_DESCRIPTION")
-                        .themeFont(fontType: .base, fontSize: .small)
-                        .themeColor(foreground: .textTertiary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(maxWidth: .infinity)
+            let view = VStack(spacing: 18) {
+                self.createHeader()
+                self.createReceipt()
                 HStack(alignment: .center, spacing: 8) {
                     Text(localizerPathKey: "APP.GENERAL.ADVANCED")
                     Rectangle()


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-426 : add top receipt area to price triggers panel screen](https://linear.app/dydx/issue/MOB-426/add-top-receipt-area-to-price-triggers-panel-screen)

Figma Design: https://www.figma.com/file/mKevZOfE9nj6MZpiolKYW1/dYdX-%E2%80%BA-Mobile?type=design&node-id=5621-14018&mode=design&t=7E3Vb2v9pYk9iSIX-4



<br/>

## Description / Intuition
- adds receipt area to price triggers screen
- note even though feature is incomplete, it is behind `#if DEBUG`



<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/ee4ae6e1-ced9-4ced-886a-4700fb0a8b14"> |



<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
