### PR TITLE
show in-app alerts setting for non-debug mode

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_Features/settings.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/settings.json
@@ -11,6 +11,14 @@
             },
             {
                 "title" : {
+                    "text" : "APP.V4.NOTIFICATIONS"
+                },
+                "link" : {
+                    "text" : "/settings/notifications"
+                }
+            },
+            {
+                "title" : {
                     "text" : "APP.V4.THEME"
                 },
                 "link" : {


### PR DESCRIPTION
continuation of https://github.com/dydxprotocol/v4-native-ios/pull/124

the notifications menu item was not showing in non-debug mode