### PR TITLE
initialize settings dict with default values

### DIFF
--- a/dydx/dydx.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dydx/dydx.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e085067eee7983e4ba42c06fd96e9ea3884445575db37e125bed61bde5eeb3f1",
+  "originHash" : "88543d81b4a86ec65b1198c6ab256bcf4b1e2df9fd2999be035f8439425324e7",
   "pins" : [
     {
       "identity" : "bigint",
@@ -35,15 +35,6 @@
       "state" : {
         "revision" : "0a06575f4038b504e78ac330913d920f1630f510",
         "version" : "2.0.2"
-      }
-    },
-    {
-      "identity" : "percy-xcui-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/percy/percy-xcui-swift",
-      "state" : {
-        "revision" : "a2e9a86dfc3f5b69ef53cbda28a0ea71098c9f77",
-        "version" : "1.0.0"
       }
     },
     {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/KeyValueStoreProtocolStore+Ext.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/KeyValueStoreProtocolStore+Ext.swift
@@ -9,13 +9,13 @@ import Foundation
 import Utilities
 import dydxViews
 
-enum dydxSettingsStoreKey: String {
+public enum dydxSettingsStoreKey: String, CaseIterable {
     case language = "language"
     case v4Theme = "v4_theme"
     case directionColorPreference = "direction_color_preference"
     case shouldDisplayInAppNotifications = "should_display_in_app_notifications"
 
-    var defaultValue: Any? {
+    public var defaultValue: Any? {
         switch self {
         case .language: return DataLocalizer.shared?.language
         case .v4Theme: return dydxThemeType.dark.rawValue

--- a/dydxV4/dydxV4.xcodeproj/project.pbxproj
+++ b/dydxV4/dydxV4.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		02FF092F29ADBD9F00781EDA /* dydxChart.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 029E11EB29ADB9BC00FE271C /* dydxChart.framework */; };
 		02FF093029ADBDA300781EDA /* dydxPresenters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0293B66528CE94E200DDB103 /* dydxPresenters.framework */; };
 		274F43062BA4C0B400645059 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 274F43052BA4C0B400645059 /* PrivacyInfo.xcprivacy */; };
+		27ADEE6C2BC4A23400B8F1DB /* dydxSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27ADEE6B2BC4A23400B8F1DB /* dydxSettingsStore.swift */; };
 		27D41AF12A8E9214009A2F37 /* UIApplication+URLHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D41AF02A8E9214009A2F37 /* UIApplication+URLHandler.swift */; };
 		27DBDD222A8FF5B2002383C6 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 27DBDCED2A8FF5B2002383C6 /* GoogleService-Info.plist */; };
 		27DBDD232A8FF5B2002383C6 /* GoogleService-Info-Staging.plist in Resources */ = {isa = PBXBuildFile; fileRef = 27DBDD202A8FF5B2002383C6 /* GoogleService-Info-Staging.plist */; };
@@ -797,6 +798,7 @@
 		02E7DD9A28CFB31000727949 /* dydxStateManager.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = dydxStateManager.xcodeproj; path = ../dydx/dydxStateManager/dydxStateManager.xcodeproj; sourceTree = "<group>"; };
 		171807B0CCAE5C86B5D65793 /* Pods_iOS_dydxV4.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_dydxV4.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		274F43052BA4C0B400645059 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		27ADEE6B2BC4A23400B8F1DB /* dydxSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxSettingsStore.swift; sourceTree = "<group>"; };
 		27D41AF02A8E9214009A2F37 /* UIApplication+URLHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+URLHandler.swift"; sourceTree = "<group>"; };
 		27DBDCED2A8FF5B2002383C6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		27DBDD202A8FF5B2002383C6 /* GoogleService-Info-Staging.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Staging.plist"; sourceTree = "<group>"; };
@@ -1050,9 +1052,10 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		27A796482A620BE4007C3D04 /* _Settings */ = {
+		27ADEE6D2BC4A23B00B8F1DB /* _Settings */ = {
 			isa = PBXGroup;
 			children = (
+				27ADEE6B2BC4A23400B8F1DB /* dydxSettingsStore.swift */,
 			);
 			path = _Settings;
 			sourceTree = "<group>";
@@ -1085,11 +1088,11 @@
 		3112F461216BBF8400708927 /* dydx */ = {
 			isa = PBXGroup;
 			children = (
-				27A796482A620BE4007C3D04 /* _Settings */,
 				0262F07429DB3989009889E2 /* _Localizer */,
 				0217A07D29D78B10007F31C5 /* _Security */,
 				314C365224C7CC5100695F7E /* _Configurations */,
 				02756A38287CA32B00803741 /* _Notification */,
+				27ADEE6D2BC4A23B00B8F1DB /* _Settings */,
 				64AF480F281880A300EBFDC6 /* _Tracking */,
 				3112F462216BBF8400708927 /* AppDelegate.swift */,
 				3112F46B216BBF8500708927 /* Assets.xcassets */,
@@ -2280,6 +2283,7 @@
 				27D41AF12A8E9214009A2F37 /* UIApplication+URLHandler.swift in Sources */,
 				02756A6A287CA33E00803741 /* dydxNotificationHandlerDelegate.swift in Sources */,
 				3112F463216BBF8400708927 /* AppDelegate.swift in Sources */,
+				27ADEE6C2BC4A23400B8F1DB /* dydxSettingsStore.swift in Sources */,
 				3101FC582511508800AC4010 /* CommonAppDelegate.swift in Sources */,
 				0217A0A129D78BD5007F31C5 /* dydxBiometricsLocalAuthenticator.swift in Sources */,
 				64AF4811281880B100EBFDC6 /* dydxAmplitudeTracking.swift in Sources */,

--- a/dydxV4/dydxV4/AppDelegate.swift
+++ b/dydxV4/dydxV4/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: CommonAppDelegate {
     override public init() {
         super.init()
         LocalAuthenticator.shared = dydxBiometricsLocalAuthenticator()
-        SettingsStore.shared = DebugSettingsStore(tag: "Settings")
+        SettingsStore.shared = dydxSettingsStore()
         DebugSettings.shared = SettingsStore.shared
         FeatureFlagsStore.shared = FeatureFlagsStore(tag: "FeatureFlags")
     }

--- a/dydxV4/dydxV4/_Settings/dydxSettingsStore.swift
+++ b/dydxV4/dydxV4/_Settings/dydxSettingsStore.swift
@@ -1,0 +1,21 @@
+//
+//  dydxSettingsStore.swift
+//  dydxV4
+//
+//  Created by Michael Maguire on 4/8/24.
+//  Copyright © 2024 dYdX Trading Inc. All rights reserved.
+//
+
+import Utilities
+import dydxPresenters
+
+class dydxSettingsStore: DebugSettingsStore {
+    init() {
+        super.init(tag: "Settings")
+        for key in dydxSettingsStoreKey.allCases {
+            if value(forKey: key.rawValue) == nil {
+                setValue(key.defaultValue, forKey: key.rawValue)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description / Intuition
issue was that for a fresh app install, there were no default settings values which does not interact well with prefilling the settings screens. The result was that a user would initially have settings active (default behavior), but there was no value set in the SettingsStore so when user would navigate to settings screen, it would appear as off which is misleading.

the fix was to initialize settings store with default values

note in the recording, it exhibits what happens now when the app is uninstalled and reinstalled to imitate a fresh install


<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/522b50e4-014f-4e13-9617-d41c8d8e13ae"> |







<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
