### PR TITLE
Allow null ethereamAddress when starting up Abacus at launch.

### DIFF
--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -210,8 +210,8 @@ public final class AbacusStateManager: NSObject {
     }
 
     private func reallyStart() {
-        if let ethereumAddress = _walletState.currentWallet?.ethereumAddress,
-           let cosmoAddress = _walletState.currentWallet?.cosmoAddress,
+        let ethereumAddress = _walletState.currentWallet?.ethereumAddress
+        if let cosmoAddress = _walletState.currentWallet?.cosmoAddress,
            let mnemonic = _walletState.currentWallet?.mnemonic {
             let walletId = _walletState.currentWallet?.walletId
             setV4(ethereumAddress: ethereumAddress, walletId: walletId, cosmoAddress: cosmoAddress, mnemonic: mnemonic)


### PR DESCRIPTION

<br/>

## Description / Intuition

When user connects to QR code (i.e., when eEtheream address is null), we used to have bug that wrote the cosmos address to etheream address field.  It was fixed from the last release, but we also need to remove the null ethereamAddress check when starting up Abacus at launch.  Otherwise, user-related info won't be available.



<br/>




<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
