### PR TITLE
MOB-467 : Wait for submission to complete before dismissing

### DIFF
--- a/Utilities/Utilities.xcodeproj/project.pbxproj
+++ b/Utilities/Utilities.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		02F958052A182BC400828F9A /* SecureStoreProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F958042A182BC400828F9A /* SecureStoreProtocol.swift */; };
 		279B87992B97CD4C00466392 /* PointsRating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279B87972B97CD4C00466392 /* PointsRating.swift */; };
 		279B879A2B97CD4C00466392 /* RatingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 279B87982B97CD4C00466392 /* RatingService.swift */; };
+		27E31E5B2BE40E4000580E59 /* SynchronizedLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E31E5A2BE40E4000580E59 /* SynchronizedLock.swift */; };
 		3101F94725112C4100AC4010 /* AuthProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3101F94625112C4100AC4010 /* AuthProtocol.swift */; };
 		3101F94A25112C5900AC4010 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3101F94925112C5900AC4010 /* AuthService.swift */; };
 		310E61E9216C0F910043BB33 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 310E61E8216C0F910043BB33 /* Security.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -302,6 +303,7 @@
 		02F958042A182BC400828F9A /* SecureStoreProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStoreProtocol.swift; sourceTree = "<group>"; };
 		279B87972B97CD4C00466392 /* PointsRating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PointsRating.swift; sourceTree = "<group>"; };
 		279B87982B97CD4C00466392 /* RatingService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RatingService.swift; sourceTree = "<group>"; };
+		27E31E5A2BE40E4000580E59 /* SynchronizedLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedLock.swift; sourceTree = "<group>"; };
 		3101F94625112C4100AC4010 /* AuthProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthProtocol.swift; sourceTree = "<group>"; };
 		3101F94925112C5900AC4010 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		310E61E8216C0F910043BB33 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -643,6 +645,7 @@
 				025B752C28A7041600A4AC98 /* ClassLoader.swift */,
 				0253CEC12A9FFF8D0033F064 /* CachedFileLoader.swift */,
 				648327432AF5665600012B75 /* NumericUtils.swift */,
+				27E31E5A2BE40E4000580E59 /* SynchronizedLock.swift */,
 			);
 			path = _Utils;
 			sourceTree = "<group>";
@@ -1380,6 +1383,7 @@
 				314B640023DCCF0200139EB3 /* MapArea.swift in Sources */,
 				6476164127E23FBC008ACFD9 /* LocalAuthenticator.swift in Sources */,
 				314B644823DCCF0200139EB3 /* NotificationToken.swift in Sources */,
+				27E31E5B2BE40E4000580E59 /* SynchronizedLock.swift in Sources */,
 				3162C00A24C377EF00DE648C /* PrompterFactory.swift in Sources */,
 				314B646C23DCCF0200139EB3 /* XibLoader.swift in Sources */,
 				279B879A2B97CD4C00466392 /* RatingService.swift in Sources */,

--- a/Utilities/Utilities/_Utils/SynchronizedLock.swift
+++ b/Utilities/Utilities/_Utils/SynchronizedLock.swift
@@ -1,0 +1,35 @@
+//
+//  SynchronizedLock.swift
+//  Utilities
+//
+//  Created by Michael Maguire on 5/2/24.
+//  Copyright © 2024 dYdX Trading Inc. All rights reserved.
+//
+
+
+import Darwin
+
+@propertyWrapper
+public struct SynchronizedLock<Value> {
+    private var value: Value
+    private var lock = NSLock()
+
+    public var wrappedValue: Value {
+        get { lock.synchronized { value } }
+        set { lock.synchronized { value = newValue } }
+    }
+
+    public init(wrappedValue value: Value) {
+        self.value = value
+    }
+}
+
+private extension NSLock {
+
+    @discardableResult
+    func synchronized<T>(_ block: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        return block()
+    }
+}

--- a/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
@@ -44,7 +44,7 @@ private protocol dydxTakeProfitStopLossViewPresenterProtocol: HostedViewPresente
 private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeProfitStopLossViewModel>, dydxTakeProfitStopLossViewPresenterProtocol {
     fileprivate var marketId: String?
     @SynchronizedLock private var pendingOrders: Int?
-    
+
     deinit {
         clearTriggersInput()
     }
@@ -180,13 +180,13 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
 
         let formattedTakeProfitUsdcDiff = dydxFormatter.shared.raw(number: triggerOrdersInput?.takeProfitOrder?.price?.usdcDiff?.doubleValue, digits: 2) ?? ""
         let formattedTakeProfitUsdcPercentage = dydxFormatter.shared.raw(number: triggerOrdersInput?.takeProfitOrder?.price?.percentDiff?.doubleValue, digits: 2) ?? ""
-        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.dollars = formattedTakeProfitUsdcDiff
-        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.percentage = formattedTakeProfitUsdcPercentage
+        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.set(value: formattedTakeProfitUsdcDiff, forUnit: .dollars)
+        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.set(value: formattedTakeProfitUsdcPercentage, forUnit: .percentage)
 
         let formattedStopLossUsdcDiff = dydxFormatter.shared.raw(number: triggerOrdersInput?.stopLossOrder?.price?.usdcDiff?.doubleValue, digits: 2) ?? ""
         let formattedStopLossUsdcPercentage = dydxFormatter.shared.raw(number: triggerOrdersInput?.stopLossOrder?.price?.percentDiff?.doubleValue, digits: 2) ?? ""
-        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.dollars = formattedStopLossUsdcDiff
-        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.percentage = formattedStopLossUsdcPercentage
+        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.set(value: formattedStopLossUsdcDiff, forUnit: .dollars)
+        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.set(value: formattedStopLossUsdcPercentage, forUnit: .percentage)
 
         // logic primarily to pre-populate custom amount. need to account 3 situations: 1 take profit order or 1 stop loss order or both
         if let customSize = triggerOrdersInput?.size?.doubleValue.magnitude, customSize != position?.size?.current?.doubleValue.magnitude {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
@@ -188,8 +188,9 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
         viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.set(value: formattedStopLossUsdcDiff, forUnit: .dollars)
         viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.set(value: formattedStopLossUsdcPercentage, forUnit: .percentage)
 
-        // logic primarily to pre-populate custom amount. need to account 3 situations: 1 take profit order or 1 stop loss order or both
-        if let customSize = triggerOrdersInput?.size?.doubleValue.magnitude, customSize != position?.size?.current?.doubleValue.magnitude {
+        // logic primarily to pre-populate custom amount.
+        // we do not want to turn on custom amount if it is not already on and the order size is the same amount as the position size. The custom amount may already be on if user manually turned it on, or a pre-existing custom amount exists that is less than the position size
+        if let customSize = triggerOrdersInput?.size?.doubleValue.magnitude, customSize != position?.size?.current?.doubleValue.magnitude || viewModel?.customAmountViewModel?.isOn == true {
             let formattedSize = dydxFormatter.shared.raw(number: customSize, digits: marketConfig.displayStepSizeDecimals?.intValue ?? 2)
             viewModel?.customAmountViewModel?.programmaticallySet(newValue: formattedSize)
         }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
@@ -148,6 +148,10 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
 
         viewModel?.takeProfitStopLossInputAreaViewModel?.takeProfitAlert = nil
         viewModel?.takeProfitStopLossInputAreaViewModel?.stopLossAlert = nil
+
+        viewModel?.takeProfitStopLossInputAreaViewModel?.takeProfitPriceInputViewModel?.hasInputError = false
+        viewModel?.takeProfitStopLossInputAreaViewModel?.stopLossPriceInputViewModel?.hasInputError = false
+
         viewModel?.customLimitPriceViewModel?.alert = nil
 
         if let error = errors.first {
@@ -155,9 +159,11 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
                 let alert = InlineAlertViewModel(.init(title: error.resources.title?.localizedString, body: error.resources.text?.localizedString, level: .error))
                 switch field {
                 case TriggerOrdersInputField.stoplossprice.rawValue, TriggerOrdersInputField.stoplossusdcdiff.rawValue, TriggerOrdersInputField.stoplosspercentdiff.rawValue:
+                    viewModel?.takeProfitStopLossInputAreaViewModel?.stopLossPriceInputViewModel?.hasInputError = true
                     viewModel?.takeProfitStopLossInputAreaViewModel?.stopLossAlert = alert
                 case TriggerOrdersInputField.takeprofitprice.rawValue, TriggerOrdersInputField.takeprofitusdcdiff.rawValue, TriggerOrdersInputField.takeprofitpercentdiff.rawValue:
                     viewModel?.takeProfitStopLossInputAreaViewModel?.takeProfitAlert = alert
+                    viewModel?.takeProfitStopLossInputAreaViewModel?.takeProfitPriceInputViewModel?.hasInputError = true
                 case TriggerOrdersInputField.takeprofitlimitprice.rawValue, TriggerOrdersInputField.stoplosslimitprice.rawValue:
                     viewModel?.customLimitPriceViewModel?.alert = alert
                 default:
@@ -210,7 +216,6 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
 
     private func update(subaccountPositions: [SubaccountPosition], triggerOrders: [SubaccountOrder], configsMap: [String: MarketConfigsAndAsset]) {
         guard let marketConfig = configsMap[marketId ?? ""]?.configs else { return }
-        // TODO: move this logic to abacus
         let position = subaccountPositions.first { subaccountPosition in
             subaccountPosition.id == marketId
         }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewPresenter.swift
@@ -43,7 +43,8 @@ private protocol dydxTakeProfitStopLossViewPresenterProtocol: HostedViewPresente
 
 private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeProfitStopLossViewModel>, dydxTakeProfitStopLossViewPresenterProtocol {
     fileprivate var marketId: String?
-
+    @SynchronizedLock private var pendingOrders: Int?
+    
     deinit {
         clearTriggersInput()
     }
@@ -179,13 +180,13 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
 
         let formattedTakeProfitUsdcDiff = dydxFormatter.shared.raw(number: triggerOrdersInput?.takeProfitOrder?.price?.usdcDiff?.doubleValue, digits: 2) ?? ""
         let formattedTakeProfitUsdcPercentage = dydxFormatter.shared.raw(number: triggerOrdersInput?.takeProfitOrder?.price?.percentDiff?.doubleValue, digits: 2) ?? ""
-        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.programmaticallySet(value: formattedTakeProfitUsdcDiff, forUnit: .dollars)
-        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.programmaticallySet(value: formattedTakeProfitUsdcPercentage, forUnit: .percentage)
+        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.dollars = formattedTakeProfitUsdcDiff
+        viewModel?.takeProfitStopLossInputAreaViewModel?.gainInputViewModel?.percentage = formattedTakeProfitUsdcPercentage
 
         let formattedStopLossUsdcDiff = dydxFormatter.shared.raw(number: triggerOrdersInput?.stopLossOrder?.price?.usdcDiff?.doubleValue, digits: 2) ?? ""
         let formattedStopLossUsdcPercentage = dydxFormatter.shared.raw(number: triggerOrdersInput?.stopLossOrder?.price?.percentDiff?.doubleValue, digits: 2) ?? ""
-        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.programmaticallySet(value: formattedStopLossUsdcDiff, forUnit: .dollars)
-        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.programmaticallySet(value: formattedStopLossUsdcPercentage, forUnit: .percentage)
+        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.dollars = formattedStopLossUsdcDiff
+        viewModel?.takeProfitStopLossInputAreaViewModel?.lossInputViewModel?.percentage = formattedStopLossUsdcPercentage
 
         // logic primarily to pre-populate custom amount. need to account 3 situations: 1 take profit order or 1 stop loss order or both
         if let customSize = triggerOrdersInput?.size?.doubleValue.magnitude, customSize != position?.size?.current?.doubleValue.magnitude {
@@ -321,24 +322,7 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
         viewModel.takeProfitStopLossInputAreaViewModel?.takeProfitPriceInputViewModel = .init(title: DataLocalizer.shared?.localize(path: "APP.TRIGGERS_MODAL.TP_PRICE", params: nil))
         viewModel.takeProfitStopLossInputAreaViewModel?.stopLossPriceInputViewModel = .init(title: DataLocalizer.shared?.localize(path: "APP.TRIGGERS_MODAL.SL_PRICE", params: nil))
 
-        viewModel.takeProfitStopLossInputAreaViewModel?.gainInputViewModel = .init(triggerType: .takeProfit) { (value, unit) in
-            switch unit {
-            case .dollars:
-                AbacusStateManager.shared.triggerOrders(input: value, type: .takeprofitusdcdiff)
-            case .percentage:
-                AbacusStateManager.shared.triggerOrders(input: value, type: .takeprofitpercentdiff)
-            }
-        }
-        viewModel.takeProfitStopLossInputAreaViewModel?.lossInputViewModel = .init(triggerType: .stopLoss) { (value, unit) in
-            switch unit {
-            case .dollars:
-                AbacusStateManager.shared.triggerOrders(input: value, type: .stoplossusdcdiff)
-            case .percentage:
-                AbacusStateManager.shared.triggerOrders(input: value, type: .stoplosspercentdiff)
-            }
-        }
-
-#if DEBUG
+        #if DEBUG
         viewModel.shouldDisplayCustomLimitPriceViewModel = AbacusStateManager.shared.environment?.featureFlags.isSlTpLimitOrdersEnabled == true
         #endif
 
@@ -365,6 +349,22 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
         }
         viewModel.customLimitPriceViewModel?.stopLossPriceInputViewModel?.onEdited = {
             AbacusStateManager.shared.triggerOrders(input: $0, type: .stoplosslimitprice)
+        }
+        viewModel.takeProfitStopLossInputAreaViewModel?.gainInputViewModel = .init(triggerType: .takeProfit) { (value, unit) in
+            switch unit {
+            case .dollars:
+                AbacusStateManager.shared.triggerOrders(input: value, type: .takeprofitusdcdiff)
+            case .percentage:
+                AbacusStateManager.shared.triggerOrders(input: value, type: .takeprofitpercentdiff)
+            }
+        }
+        viewModel.takeProfitStopLossInputAreaViewModel?.lossInputViewModel = .init(triggerType: .stopLoss) { (value, unit) in
+            switch unit {
+            case .dollars:
+                AbacusStateManager.shared.triggerOrders(input: value, type: .stoplossusdcdiff)
+            case .percentage:
+                AbacusStateManager.shared.triggerOrders(input: value, type: .stoplosspercentdiff)
+            }
         }
 
         // set up toggle interactions
@@ -406,9 +406,6 @@ private class dydxTakeProfitStopLossViewPresenter: HostedViewPresenter<dydxTakeP
 
         self.viewModel = viewModel
     }
-
-    @SynchronizedLock var pendingOrders: Int?
-
 }
 
 private extension Abacus.OrderSide {
@@ -418,32 +415,5 @@ private extension Abacus.OrderSide {
         case .sell: return .long_
         default: return .short_
         }
-    }
-}
-
-import Darwin
-
-@propertyWrapper
-public struct SynchronizedLock<Value> {
-    private var value: Value
-    private var lock = NSLock()
-
-    public var wrappedValue: Value {
-        get { lock.synchronized { value } }
-        set { lock.synchronized { value = newValue } }
-    }
-
-    public init(wrappedValue value: Value) {
-        self.value = value
-    }
-}
-
-private extension NSLock {
-
-    @discardableResult
-    func synchronized<T>(_ block: () -> T) -> T {
-        lock()
-        defer { unlock() }
-        return block()
     }
 }

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -429,14 +429,22 @@ extension AbacusStateManager {
         case failed(Abacus.ParsingError?)
     }
 
-    public func placeTriggerOrders(callback: @escaping ((SubmissionStatus) -> Void)) {
-        asyncStateManager.commitTriggerOrders { successful, error, _ in
+    public func placeTriggerOrders(callback: @escaping ((SubmissionStatus) -> Void)) -> Int? {
+//        let task = Task {
+//            
+//        }
+        let payload = asyncStateManager.commitTriggerOrders { successful, error, _ in
             if successful.boolValue {
                 callback(.success)
             } else {
                 callback(.failed(error))
             }
         }
+        let placeOrderPayloads = payload?.placeOrderPayloads ?? []
+        let cancelPayloads = payload?.cancelOrderPayloads ?? []
+        print("mmm: \(placeOrderPayloads.count + cancelPayloads.count)")
+        return placeOrderPayloads.count + cancelPayloads.count
+
     }
 
     public func placeOrder(callback: @escaping ((SubmissionStatus) -> Void)) {

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -428,7 +428,9 @@ extension AbacusStateManager {
         case success
         case failed(Abacus.ParsingError?)
     }
-
+    
+    /// places the currently drafted trigger order(s)
+    /// - Returns: the number of resulting cancel orders + place order requests
     public func placeTriggerOrders(callback: @escaping ((SubmissionStatus) -> Void)) -> Int? {
         let payload = asyncStateManager.commitTriggerOrders { successful, error, _ in
             if successful.boolValue {

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -428,7 +428,7 @@ extension AbacusStateManager {
         case success
         case failed(Abacus.ParsingError?)
     }
-    
+
     /// places the currently drafted trigger order(s)
     /// - Returns: the number of resulting cancel orders + place order requests
     public func placeTriggerOrders(callback: @escaping ((SubmissionStatus) -> Void)) -> Int? {

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -430,9 +430,6 @@ extension AbacusStateManager {
     }
 
     public func placeTriggerOrders(callback: @escaping ((SubmissionStatus) -> Void)) -> Int? {
-//        let task = Task {
-//            
-//        }
         let payload = asyncStateManager.commitTriggerOrders { successful, error, _ in
             if successful.boolValue {
                 callback(.success)
@@ -442,9 +439,7 @@ extension AbacusStateManager {
         }
         let placeOrderPayloads = payload?.placeOrderPayloads ?? []
         let cancelPayloads = payload?.cancelOrderPayloads ?? []
-        print("mmm: \(placeOrderPayloads.count + cancelPayloads.count)")
         return placeOrderPayloads.count + cancelPayloads.count
-
     }
 
     public func placeOrder(callback: @escaping ((SubmissionStatus) -> Void)) {

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxCustomAmountViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxCustomAmountViewModel.swift
@@ -13,7 +13,7 @@ import Utilities
 
 public class dydxCustomAmountViewModel: PlatformTextInputViewModel {
 
-    @Published private var isOn: Bool = false
+    @Published private (set) public var isOn: Bool = false
     @Published public var toggleAction: ((Bool) -> Void)?
 
     @Published public var assetId: String? {

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxGainLossInputViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxGainLossInputViewModel.swift
@@ -10,45 +10,207 @@ import SwiftUI
 import PlatformUI
 import dydxFormatter
 import Utilities
+import Popovers
 
-public class dydxGainLossInputViewModel: PlatformTextInputViewModel {
-    public init(triggerType: dydxTakeProfitStopLossInputAreaModel.TriggerType, onEdited: ((String?) -> Void)? = nil) {
-        super.init(
-            label: DataLocalizer.shared?.localize(path: triggerType.gainLossInputTitleLocalizerPath, params: nil),
-            placeHolder: dydxFormatter.shared.dollar(number: 0.0, digits: 0),
-            // TODO: replace when percentage input is in abacus
-//            valueAccessoryView: accessoryView,
-            inputType: .decimalDigits,
-            onEdited: onEdited
-        )
+public class dydxGainLossInputViewModel: PlatformViewModeling {
+
+    public enum Unit: CaseIterable {
+        case dollars
+        case percentage
+
+        var displayText: String {
+            switch self {
+            case .dollars:
+                return "$"
+            case .percentage:
+                return "%"
+            }
+        }
     }
 
-    public static var previewValue: dydxGainLossInputViewModel = {
-        let vm = dydxGainLossInputViewModel(triggerType: .takeProfit)
-        return vm
-    }()
+    @Published fileprivate var isFocused: Bool = false
+    @Published fileprivate var triggerType: dydxTakeProfitStopLossInputAreaModel.TriggerType
+    @Published fileprivate var curUnit: Unit = .percentage
+    @Published fileprivate var onEdited: ((String?, Unit) -> Void)?
+    @Published fileprivate var isPresentingUnitOptions: Bool = false
 
-    public override func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformView {
-        let view = super.createView(parentStyle: parentStyle, styleKey: styleKey)
-        return PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] _  in
-            return view
-                .makeInput()
-                .wrappedInAnyView()
+    @Published fileprivate var dollars: String = ""
+    @Published fileprivate var percentage: String = ""
+
+    fileprivate var displayText: String {
+        switch curUnit {
+        case .dollars:
+            return dollars
+        case .percentage:
+            return percentage
         }
+    }
+
+    /// Attempts to set the value for the unit. Will not set if actively editing/has focus.
+    public func programmaticallySet(value: String, forUnit unit: Unit) {
+        switch unit {
+        case .dollars:
+            dollars = value
+        case .percentage:
+            percentage = value
+        }
+    }
+
+    public func clear() {
+        dollars = ""
+        percentage = ""
+    }
+
+    public init(triggerType: dydxTakeProfitStopLossInputAreaModel.TriggerType, onEdited: ((String?, Unit) -> Void)? = nil) {
+        self.triggerType = triggerType
+        self.onEdited = onEdited
+    }
+
+    public func createView(parentStyle: ThemeStyle, styleKey: String?) -> some View {
+        dydxGainLossInputView(viewModel: self)
     }
 }
 
-#if DEBUG
-struct dydxGainLossInputViewModel_Previews: PreviewProvider {
-    @StateObject static var themeSettings = ThemeSettings.shared
+/// note, we cannot use PlatformView because this view manages focus which requires using @FocusState which cannot be used for classes. @FocusState is necessary for Popover interaction
+struct dydxGainLossInputView: View {
 
-    static var previews: some View {
-        Group {
-            dydxGainLossInputViewModel.previewValue
-                .createView()
-                .environmentObject(themeSettings)
-                .previewLayout(.sizeThatFits)
+    @FocusState private var isFocused: Bool
+    @State private var text: String
+    @ObservedObject private var viewModel: dydxGainLossInputViewModel
+
+    fileprivate init(viewModel: dydxGainLossInputViewModel) {
+        self.viewModel = viewModel
+        switch viewModel.curUnit {
+            case .dollars:
+                text = viewModel.dollars
+            case .percentage:
+                text = viewModel.percentage
+        }
+    }
+
+    var header: some View {
+        Text(DataLocalizer.shared?.localize(path: viewModel.triggerType.gainLossInputTitleLocalizerPath, params: nil) ?? "")
+            .themeColor(foreground: .textTertiary)
+            .themeFont(fontSize: .smaller)
+    }
+
+    var placeholder: Text {
+        Text("0")
+            .themeColor(foreground: .textTertiary)
+            .themeFont(fontType: .number, fontSize: .large)
+    }
+
+    var textInput: some View {
+        let textField = TextField("", text: $text, prompt: placeholder)
+            .themeFont(fontType: .number, fontSize: .large)
+            .themeColor(foreground: .textPrimary)
+            .keyboardType(.decimalPad)
+            .focused($isFocused)
+        if #available(iOS 17.0, *) {
+            return textField
+                .onChange(of: text) { _, newValue in
+                    // only propagate updates if they are from user editing
+                    guard isFocused else { return }
+                    viewModel.onEdited?(newValue, viewModel.curUnit)
+                }
+                .onChange(of: viewModel.displayText) { _, newValue in
+                    // do not overwrite user entry while user is editing
+                    guard !isFocused else { return }
+                    text = newValue
+                }
+                .onChange(of: isFocused) { _, newValue in
+                    viewModel.isFocused = newValue
+                    viewModel.onEdited?(text, viewModel.curUnit)
+                }
+        } else {
+            return textField
+                .onChange(of: text) { newValue in
+                    viewModel.onEdited?(newValue, viewModel.curUnit)
+                }
+                .onChange(of: isFocused) { newValue in
+                    viewModel.isFocused = newValue
+                    viewModel.onEdited?(text, viewModel.curUnit)
+                }
+        }
+    }
+
+    var displaySelector: some View {
+        Button(action: {
+            if !viewModel.isPresentingUnitOptions {
+                viewModel.isPresentingUnitOptions = true
+            }
+            if isFocused {
+                isFocused = false
+            }
+        }, label: {
+            Text(viewModel.curUnit.displayText)
+                .contentShape(.rect)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .borderAndClip(style: .cornerRadius(6), borderColor: .borderDefault)
+        })
+        .popover(present: $viewModel.isPresentingUnitOptions, attributes: { attrs in
+                attrs.position = .absolute(
+                           originAnchor: .bottom,
+                           popoverAnchor: .topLeft
+                       )
+                attrs.sourceFrameInset = .init(top: 0, left: 0, bottom: -16, right: 0)
+                attrs.presentation.animation = .none
+                attrs.blocksBackgroundTouches = true
+                attrs.onTapOutside = {
+                    viewModel.isPresentingUnitOptions = false
+                }
+            }, view: {
+                VStack(spacing: 0) {
+                    ForEach(Array(dydxGainLossInputViewModel.Unit.allCases.enumerated()), id: \.element) { index, unit in
+                        Button {
+                            viewModel.curUnit = unit
+                            viewModel.isPresentingUnitOptions = false
+                        } label: {
+                            Text(unit.displayText)
+                                .themeFont(fontSize: .medium)
+                                .themeColor(foreground: .textPrimary)
+                            .contentShape(Rectangle())
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
+                        }
+
+                        let isLast = index == dydxGainLossInputViewModel.Unit.allCases.count - 1
+                        if !isLast {
+                            DividerModel().createView()
+                        }
+                    }
+                }
+                .fixedSize()
+                .themeColor(background: .layer3)
+                .borderAndClip(style: .cornerRadius(8), borderColor: .borderDefault)
+                .environmentObject(ThemeSettings.shared)
+            }, background: {
+                ThemeColor.SemanticColor.layer0.color.opacity(0.7)
+            })
+            .wrappedInAnyView()
+
+    }
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                self.header
+                self.textInput
+            }
+            Spacer()
+            self.displaySelector
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+        .makeInput()
+    }
+}
+
+#Preview {
+    VStack {
+        ForEach(dydxTakeProfitStopLossInputAreaModel.TriggerType.allCases, id: \.self) { triggerType in
+            dydxGainLossInputViewModel(triggerType: triggerType).createView(parentStyle: .defaultStyle, styleKey: nil)
         }
     }
 }
-#endif

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxGainLossInputViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxGainLossInputViewModel.swift
@@ -34,8 +34,8 @@ public class dydxGainLossInputViewModel: PlatformViewModeling {
     @Published fileprivate var onEdited: ((String?, Unit) -> Void)?
     @Published fileprivate var isPresentingUnitOptions: Bool = false
 
-    @Published fileprivate var dollars: String = ""
-    @Published fileprivate var percentage: String = ""
+    @Published public var dollars: String = ""
+    @Published public var percentage: String = ""
 
     fileprivate var displayText: String {
         switch curUnit {
@@ -43,16 +43,6 @@ public class dydxGainLossInputViewModel: PlatformViewModeling {
             return dollars
         case .percentage:
             return percentage
-        }
-    }
-
-    /// Attempts to set the value for the unit. Will not set if actively editing/has focus.
-    public func programmaticallySet(value: String, forUnit unit: Unit) {
-        switch unit {
-        case .dollars:
-            dollars = value
-        case .percentage:
-            percentage = value
         }
     }
 

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxPriceInputViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxPriceInputViewModel.swift
@@ -13,6 +13,8 @@ import Utilities
 
 public class dydxPriceInputViewModel: PlatformTextInputViewModel {
 
+    @Published public var hasInputError: Bool = false
+
     public init(title: String?, onEdited: ((String?) -> Void)? = nil) {
         super.init(
             label: title,
@@ -33,6 +35,7 @@ public class dydxPriceInputViewModel: PlatformTextInputViewModel {
         return PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { _  in
             return view
                 .makeInput()
+                .border(borderWidth: 1, cornerRadius: 12, borderColor: self.hasInputError ? ThemeColor.SemanticColor.colorRed.color : .clear)
                 .wrappedInAnyView()
         }
     }

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxTakeProfitStopLossInputAreaViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxTakeProfitStopLossInputAreaViewModel.swift
@@ -108,10 +108,10 @@ public class dydxTakeProfitStopLossInputAreaModel: PlatformViewModel {
                     switch triggerType {
                     case .takeProfit:
                         self?.takeProfitPriceInputViewModel?.onEdited?(nil)
-                        self?.gainInputViewModel?.onEdited?(nil)
+                        self?.gainInputViewModel?.clear()
                     case .stopLoss:
                         self?.stopLossPriceInputViewModel?.onEdited?(nil)
-                        self?.lossInputViewModel?.onEdited?(nil)
+                        self?.lossInputViewModel?.clear()
                     }
                 }
                 .wrappedInAnyView()
@@ -165,7 +165,7 @@ public class dydxTakeProfitStopLossInputAreaModel: PlatformViewModel {
 }
 
 extension dydxTakeProfitStopLossInputAreaModel {
-    public enum TriggerType {
+    public enum TriggerType: CaseIterable {
         case takeProfit
         case stopLoss
 

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxTakeProfitStopLossInputAreaViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/Components/dydxTakeProfitStopLossInputAreaViewModel.swift
@@ -100,11 +100,12 @@ public class dydxTakeProfitStopLossInputAreaModel: PlatformViewModel {
 
     private func createClearButton(triggerType: dydxTakeProfitStopLossInputAreaModel.TriggerType) -> AnyView? {
         guard let numOrders = triggerType == .takeProfit ? numOpenTakeProfitOrders : numOpenStopLossOrders else { return nil }
-        if numOrders == 1 {
+        if numOrders <= 1 {
             return Text(localizerPathKey: "APP.GENERAL.CLEAR")
                 .themeFont(fontType: .base, fontSize: .medium)
                 .themeColor(foreground: .colorRed)
                 .onTapGesture { [weak self] in
+                    PlatformView.hideKeyboard()
                     switch triggerType {
                     case .takeProfit:
                         self?.takeProfitPriceInputViewModel?.onEdited?(nil)

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
@@ -86,7 +86,7 @@ public class dydxTakeProfitStopLossViewModel: PlatformViewModel {
         let buttonText: String
         let buttonState: PlatformButtonState
         let spinner: AnyView?
-        
+
         switch submissionReadiness {
         case .readyToSubmit:
             buttonText = DataLocalizer.shared?.localize(path: "APP.TRADE.ADD_TRIGGERS", params: nil) ?? ""
@@ -105,7 +105,7 @@ public class dydxTakeProfitStopLossViewModel: PlatformViewModel {
             buttonState = .disabled
             spinner = self.spinner
         }
-        
+
         let content = HStack(spacing: 8) {
             Spacer()
             Text(buttonText)

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import Utilities
 import Introspect
 import dydxFormatter
-import Popovers
 import KeyboardObserving
 
 public class dydxTakeProfitStopLossViewModel: PlatformViewModel {

--- a/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/TakeProfitStopLoss/dydxTakeProfitStopLossViewModel.swift
@@ -75,26 +75,41 @@ public class dydxTakeProfitStopLossViewModel: PlatformViewModel {
         }
     }
 
+    private var spinner: AnyView {
+        ProgressView()
+            .progressViewStyle(.circular)
+            .tint(ThemeColor.SemanticColor.textSecondary.color)
+            .wrappedInAnyView()
+    }
+
     private func createCta(parentStyle: ThemeStyle, styleKey: String?) -> AnyView? {
         let buttonText: String
         let buttonState: PlatformButtonState
+        let spinner: AnyView?
+        
         switch submissionReadiness {
         case .readyToSubmit:
             buttonText = DataLocalizer.shared?.localize(path: "APP.TRADE.ADD_TRIGGERS", params: nil) ?? ""
             buttonState = .primary
+            spinner = nil
         case .needsInput:
             buttonText = DataLocalizer.shared?.localize(path: "APP.TRADE.ADD_TRIGGERS", params: nil) ?? ""
             buttonState = .disabled
+            spinner = nil
         case .fixErrors(let cta):
             buttonText = cta ?? ""
             buttonState = .disabled
+            spinner = nil
         case .submitting:
             buttonText = DataLocalizer.shared?.localize(path: "APP.TRADE.SUBMITTING_ORDER", params: nil) ?? ""
             buttonState = .disabled
+            spinner = self.spinner
         }
-        let content = HStack(spacing: 0) {
+        
+        let content = HStack(spacing: 8) {
             Spacer()
             Text(buttonText)
+            spinner
             Spacer()
         }.wrappedInAnyView()
 


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-467 : Wait for submission to complete before dismissing](https://linear.app/dydx/issue/MOB-467/wait-for-submission-to-complete-before-dismissing)

Figma Design: [design](https://www.figma.com/file/mKevZOfE9nj6MZpiolKYW1/dYdX-%E2%80%BA-Mobile?type=design&node-id=5621-13400&mode=design&t=e2yHFYehPPJ67GPR-4)




<br/>

## Description / Intuition
- adds the $/% selector, note this change did not work well with PlatformInput so had to create a custom component so that we could make use of @FocusState property wrapper which is only available for structs. The @FocusState struct conforms to the DynamicProperty protocol, which is something that can only be used with View structs, not in observable objects. Otherwise, you get the runtime XCode warning.
> Accessing FocusState's value outside of the body of a View. This will result in a constant Binding of the initial value and will not update.
- added logic to wait for either (1) all orders/cancelations to succeed or (2) the first failure, before dismissing the SL/TP dialog
- adds spinner to reflect ^
- adds functionality to show red border for error field



<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| wait for all orders to finish, video contains one canceled order and one submitted order | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/ed4212b4-4312-4e1e-9e39-497ae93db9c7"> |
| $/% editing | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/b4e0022a-efce-4304-a09f-392127e2279e"> |









<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
