### PR TITLE
MOB-476 : support new read-only/close only mode

### DIFF
--- a/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
@@ -100,9 +100,19 @@ public final class AbacusState {
             .eraseToAnyPublisher()
     }
 
+    /// protocol pre v5.0
     public var restriction: AnyPublisher<Restriction, Never> {
         statePublisher
             .compactMap { $0?.restriction?.restriction ?? .noRestriction }
+            .removeDuplicates()
+            .share()
+            .eraseToAnyPublisher()
+    }
+
+    // protocol v5.0 and up
+    public var complianceStatus: AnyPublisher<ComplianceStatus, Never> {
+        statePublisher
+            .compactMap { $0?.compliance?.status }
             .removeDuplicates()
             .share()
             .eraseToAnyPublisher()


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-476 : support new read-only/close only mode](https://linear.app/dydx/issue/MOB-476/support-new-read-onlyclose-only-mode)



<br/>

## Before/After Screenshots or Videos

| -- | After |
|--------|-------|
| | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/bb509e85-9bdd-40ef-b921-10eb43e6e797"> |
|  | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/301a7927-af33-42fc-9308-320a6622e4c1"> |






<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
