### PR TITLE
MOB-478 : update copy params for new compliance status strings

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxRestrictionsWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxRestrictionsWorker.swift
@@ -24,42 +24,38 @@ public final class dydxRestrictionsWorker: BaseWorker {
             }
             .store(in: &subscriptions)
 
-        // used in protocol 4.0
-        AbacusStateManager.shared.state.complianceStatus
-            .sink { complianceStatus in
-                Self.handle(complianceStatus: complianceStatus)
+        // used in protocol 5.0
+        AbacusStateManager.shared.state.compliance
+            .sink { compliance in
+                Self.handle(compliance: compliance)
             }
             .store(in: &subscriptions)
     }
 
-    public static func handle(complianceStatus: ComplianceStatus) {
+    public static func handle(compliance: Compliance) {
         let title: String?
         let body: String?
-        switch complianceStatus {
+        switch compliance.status {
         case .compliant:
             return
         case .firstStrike, .firstStrikeCloseOnly, .closeOnly:
-            // TODO: add DATE & EMAIL
-            // [MOB-478 : update copy params for new compliance status strings](https://linear.app/dydx/issue/MOB-478/update-copy-params-for-new-compliance-status-strings)
             title = DataLocalizer.shared?.localize(
                 path: "APP.COMPLIANCE.CLOSE_ONLY_TITLE",
                 params: nil) ?? ""
             body = DataLocalizer.shared?.localize(
                 path: "APP.COMPLIANCE.CLOSE_ONLY_BODY",
                 params: [
-                    "DATE": "--",
-                    "EMAIL": "--"
+                    "DATE": compliance.expiresAt ?? "--",
+                    "EMAIL": AbacusStateManager.shared.environment?.links?.complianceSupportEmail ?? "--"
                 ]) ?? ""
         case .blocked:
-            // TODO: add DATE & EMAIL
-            // [MOB-478 : update copy params for new compliance status strings](https://linear.app/dydx/issue/MOB-478/update-copy-params-for-new-compliance-status-strings)
             title = DataLocalizer.shared?.localize(
                 path: "APP.COMPLIANCE.PERMANENTLY_BLOCKED_TITLE",
                 params: nil) ?? ""
             body = DataLocalizer.shared?.localize(
                 path: "APP.COMPLIANCE.PERMANENTLY_BLOCKED_BODY",
                 params: [
-                    "EMAIL": "--"
+                    "EMAIL": AbacusStateManager.shared.environment?.links?.complianceSupportEmail ?? "--"
                 ]) ?? ""
         default:
             return

--- a/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusState+Combine.swift
@@ -110,9 +110,9 @@ public final class AbacusState {
     }
 
     // protocol v5.0 and up
-    public var complianceStatus: AnyPublisher<ComplianceStatus, Never> {
+    public var compliance: AnyPublisher<Compliance, Never> {
         statePublisher
-            .compactMap { $0?.compliance?.status }
+            .compactMap { $0?.compliance }
             .removeDuplicates()
             .share()
             .eraseToAnyPublisher()


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-478 : update copy params for new compliance status strings](https://linear.app/dydx/issue/MOB-478/update-copy-params-for-new-compliance-status-strings)




<br/>

## Description / Intuition
- uses new `expiresAt` field and `complianceSupportEmail` in error message interpolation




<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/dbbded40-a107-44b8-bb81-ebc45fb02510" width=50%> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/72febafc-1314-4821-b6b6-3e754367b3eb" width=50%> |




<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
