### PR TITLE
fix platform list footer display logic

### DIFF
--- a/PlatformUI/PlatformUI/PlatformListViewModel.swift
+++ b/PlatformUI/PlatformUI/PlatformListViewModel.swift
@@ -19,23 +19,6 @@ open class PlatformListViewModel: PlatformViewModeling {
             contentChanged?()
         }
     }
-    public var header: PlatformViewModel? {
-        didSet {
-            contentChanged?()
-        }
-    }
-    
-    public var footer: PlatformViewModel? {
-        didSet {
-            contentChanged?()
-        }
-    }
-    
-    public var placeholder: PlatformViewModel? {
-        didSet {
-            contentChanged?()
-        }
-    }
 
     
     public var width: CGFloat? {
@@ -46,6 +29,10 @@ open class PlatformListViewModel: PlatformViewModeling {
         }
     }
     
+    open var header: PlatformViewModel? { nil }
+    open var footer: PlatformViewModel? { nil }
+    open var placeholder: PlatformViewModel? { nil }
+    
     // contentChanged is required because the list view model returns a ForEach struct
     // which does not observe the content change.  Caller should supply a contentChanged block
     // that manually triggers the parent view model's objectWillChange.send()
@@ -53,15 +40,11 @@ open class PlatformListViewModel: PlatformViewModeling {
     public var contentChanged: (() -> Void)?
 
     public init(items: [PlatformViewModel] = [], 
-                header: PlatformViewModel? = nil,
-                placeholder: PlatformViewModel? = nil,
                 intraItemSeparator: Bool = true,
                 firstListItemTopSeparator: Bool = false,
                 lastListItemBottomSeparator: Bool = false,
                 contentChanged: (() -> Void)? = nil) {
         self.items = items
-        self.header = header
-        self.placeholder = placeholder
         self.intraItemSeparator = intraItemSeparator
         self.firstListItemTopSeparator = firstListItemTopSeparator
         self.lastListItemBottomSeparator = lastListItemBottomSeparator
@@ -69,27 +52,17 @@ open class PlatformListViewModel: PlatformViewModeling {
     }
     
     open func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> AnyView {
-        guard items.count > 0 else {
-            let cell = Group {
-                    if let placeholder = self.placeholder {
-                        placeholder.createView(parentStyle: parentStyle)
-                    } else {
-                        PlatformView.nilView
-                    }
-                }
-                .frame(width: width)
-            return AnyView(cell)
-        }
         
+        let itemsOrPlaceholder = items.count > 0 ? items : [placeholder ?? .init(bodyBuilder: nil)]
         let list: [PlatformViewModel]
         if let header, let footer {
-            list = [header] + items + [footer]
+            list = [header] + itemsOrPlaceholder + [footer]
         } else if let header {
-            list = [header] + items
+            list = [header] + itemsOrPlaceholder
         } else if let footer {
-            list = items + [footer]
+            list = itemsOrPlaceholder + [footer]
         } else {
-            list = items
+            list = itemsOrPlaceholder
         }
         
         return AnyView(
@@ -99,7 +72,8 @@ open class PlatformListViewModel: PlatformViewModeling {
                         let cell =
                         Group {
                             // render the item if it is a header or a footer and the index is first or last
-                            if (item === list.first && self?.header != nil) || (item === list.last && self?.footer != nil)  {
+                            // or if items is empty (and placeholder is being displayed)
+                            if (item === list.first && self?.header != nil) || (item === list.last && self?.footer != nil) || self?.items.isEmpty != false {
                                 item.createView(parentStyle: parentStyle)
                             } else {
                                 VStack(alignment: .leading, spacing: 0) {

--- a/PlatformUI/PlatformUI/PlatformListViewModel.swift
+++ b/PlatformUI/PlatformUI/PlatformListViewModel.swift
@@ -19,23 +19,6 @@ open class PlatformListViewModel: PlatformViewModeling {
             contentChanged?()
         }
     }
-    public var header: PlatformViewModel? {
-        didSet {
-            contentChanged?()
-        }
-    }
-    
-    public var footer: PlatformViewModel? {
-        didSet {
-            contentChanged?()
-        }
-    }
-    
-    public var placeholder: PlatformViewModel? {
-        didSet {
-            contentChanged?()
-        }
-    }
 
     
     public var width: CGFloat? {
@@ -53,43 +36,33 @@ open class PlatformListViewModel: PlatformViewModeling {
     public var contentChanged: (() -> Void)?
 
     public init(items: [PlatformViewModel] = [], 
-                header: PlatformViewModel? = nil,
-                placeholder: PlatformViewModel? = nil,
                 intraItemSeparator: Bool = true,
                 firstListItemTopSeparator: Bool = false,
                 lastListItemBottomSeparator: Bool = false,
                 contentChanged: (() -> Void)? = nil) {
         self.items = items
-        self.header = header
-        self.placeholder = placeholder
         self.intraItemSeparator = intraItemSeparator
         self.firstListItemTopSeparator = firstListItemTopSeparator
         self.lastListItemBottomSeparator = lastListItemBottomSeparator
         self.contentChanged = contentChanged
     }
     
+    open var header: PlatformViewModel? { nil }
+    open var footer: PlatformViewModel? { nil }
+    open var placeholder: PlatformViewModel? { nil }
+    
     open func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> AnyView {
-        guard items.count > 0 else {
-            let cell = Group {
-                    if let placeholder = self.placeholder {
-                        placeholder.createView(parentStyle: parentStyle)
-                    } else {
-                        PlatformView.nilView
-                    }
-                }
-                .frame(width: width)
-            return AnyView(cell)
-        }
         
+        let itemsOrPlaceholder = items.count > 0 ? items : [placeholder ?? .init(bodyBuilder: nil)]
         let list: [PlatformViewModel]
         if let header, let footer {
-            list = [header] + items + [footer]
+            list = [header] + itemsOrPlaceholder + [footer]
         } else if let header {
-            list = [header] + items
+            list = [header] + itemsOrPlaceholder
         } else if let footer {
-            list = items + [footer]
+            list = itemsOrPlaceholder + [footer]
         } else {
-            list = items
+            list = itemsOrPlaceholder
         }
         
         return AnyView(
@@ -99,7 +72,8 @@ open class PlatformListViewModel: PlatformViewModeling {
                         let cell =
                         Group {
                             // render the item if it is a header or a footer and the index is first or last
-                            if (item === list.first && self?.header != nil) || (item === list.last && self?.footer != nil)  {
+                            // or if items is empty (and placeholder is being displayed)
+                            if (item === list.first && self?.header != nil) || (item === list.last && self?.footer != nil) || self?.items.isEmpty != false {
                                 item.createView(parentStyle: parentStyle)
                             } else {
                                 VStack(alignment: .leading, spacing: 0) {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioOrdersViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioOrdersViewPresenter.swift
@@ -36,6 +36,8 @@ class dydxPortfolioOrdersViewPresenter: HostedViewPresenter<dydxPortfolioOrdersV
 
         AbacusStateManager.shared.state.onboarded
             .sink { [weak self] onboarded in
+                // TODO: remove once isolated markets is supported and force released
+                self?.viewModel?.shouldDisplayIsolatedOrdersWarning = onboarded
                 if onboarded {
                     self?.viewModel?.placeholderText = DataLocalizer.localize(path: "APP.GENERAL.PLACEHOLDER_NO_ORDERS")
                 } else {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioOrdersViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioOrdersViewPresenter.swift
@@ -99,8 +99,10 @@ class dydxPortfolioOrdersViewPresenter: HostedViewPresenter<dydxPortfolioOrdersV
         item.filledSize = dydxFormatter.shared.localFormatted(number: filledSize, digits: configs.displayStepSizeDecimals?.intValue ?? 1)
         if let tickSize = configs.displayTickSizeDecimals?.intValue {
             switch order.type {
-            case .market, .stopmarket, .takeprofitmarket:
+            case .market:
                 item.price = DataLocalizer.localize(path: "APP.GENERAL.MARKET")
+            case .stopmarket, .takeprofitmarket:
+                item.price = dydxFormatter.shared.dollar(number: order.triggerPrice?.doubleValue, digits: tickSize)
             default:
                 item.price = dydxFormatter.shared.dollar(number: order.price, digits: tickSize)
             }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -34,6 +34,8 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
 
         AbacusStateManager.shared.state.onboarded
             .sink { [weak self] onboarded in
+                // TODO: remove once isolated markets is supported and force released
+                self?.viewModel?.shouldDisplayIsolatedPositionsWarning = onboarded
                 if onboarded {
                     self?.viewModel?.placeholderText = DataLocalizer.localize(path: "APP.GENERAL.PLACEHOLDER_NO_POSITIONS")
                 } else {

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFeesView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFeesView.swift
@@ -121,13 +121,12 @@ public class dydxPortfolioFeesListViewModel: PlatformListViewModel {
 
     public init() {
         super.init()
-        self.placeholder = PlatformView.nilViewModel
-        self.header = createHeader().wrappedViewModel
         self.width = UIScreen.main.bounds.width - 16
     }
 
-    private func createHeader() -> some View {
-        HStack {
+    public override var header: PlatformViewModel? {
+        guard items.count > 0 else { return nil }
+        return HStack {
             Text(DataLocalizer.localize(path: "APP.GENERAL.TIER"))
                 .leftAligned()
                 .frame(width: 70)
@@ -142,6 +141,7 @@ public class dydxPortfolioFeesListViewModel: PlatformListViewModel {
         .padding(.horizontal, 8)
         .themeFont(fontSize: .smaller)
         .themeColor(foreground: .textTertiary)
+        .wrappedViewModel
     }
 }
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFillsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFillsView.swift
@@ -11,13 +11,13 @@ import PlatformUI
 import Utilities
 
 public class dydxPortfolioFillsViewModel: PlatformListViewModel {
-    @Published public var placeholderText: String? {
-        didSet {
-            _placeholder.text = placeholderText
-        }
-    }
+    @Published public var placeholderText: String?
 
-    private let _placeholder = PlaceholderViewModel()
+    public override var placeholder: PlatformViewModel? {
+        let vm = PlaceholderViewModel()
+        vm.text = placeholderText
+        return vm
+    }
 
     public init(items: [PlatformViewModel] = [], contentChanged: (() -> Void)? = nil) {
         super.init(items: items,
@@ -25,8 +25,6 @@ public class dydxPortfolioFillsViewModel: PlatformListViewModel {
                    firstListItemTopSeparator: true,
                    lastListItemBottomSeparator: true,
                    contentChanged: contentChanged)
-        self.placeholder = _placeholder
-        self.header = createHeader().wrappedViewModel
         self.width = UIScreen.main.bounds.width - 16
     }
 
@@ -39,8 +37,9 @@ public class dydxPortfolioFillsViewModel: PlatformListViewModel {
         return vm
     }
 
-    private func createHeader() -> some View {
-        HStack {
+    public override var header: PlatformViewModel? {
+        guard items.count > 0 else { return nil }
+        return HStack {
             HStack {
                 Text(DataLocalizer.localize(path: "APP.GENERAL.TIME"))
                 Spacer()
@@ -54,6 +53,7 @@ public class dydxPortfolioFillsViewModel: PlatformListViewModel {
         .padding(.bottom, 16)
         .themeFont(fontSize: .small)
         .themeColor(foreground: .textTertiary)
+        .wrappedViewModel
     }
 }
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFundingView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioFundingView.swift
@@ -141,13 +141,13 @@ public class dydxPortfolioFundingItemViewModel: PlatformViewModel {
 }
 
 public class dydxPortfolioFundingViewModel: PlatformListViewModel {
-    @Published public var placeholderText: String? {
-        didSet {
-            _placeholder.text = placeholderText
-        }
-    }
+    @Published public var placeholderText: String?
 
-    private let _placeholder = PlaceholderViewModel()
+    public override var placeholder: PlatformViewModel? {
+        let vm = PlaceholderViewModel()
+        vm.text = placeholderText
+        return vm
+    }
 
     public init(items: [PlatformViewModel] = [], contentChanged: (() -> Void)? = nil) {
         super.init(items: items,
@@ -155,8 +155,6 @@ public class dydxPortfolioFundingViewModel: PlatformListViewModel {
                    firstListItemTopSeparator: true,
                    lastListItemBottomSeparator: true,
                    contentChanged: contentChanged)
-        self.placeholder = _placeholder
-        self.header = createHeader().wrappedViewModel
         self.width = UIScreen.main.bounds.width - 16
     }
 
@@ -169,8 +167,9 @@ public class dydxPortfolioFundingViewModel: PlatformListViewModel {
         return vm
     }
 
-    private func createHeader() -> some View {
-        HStack {
+    public override var header: PlatformViewModel? {
+        guard items.count > 0 else { return nil }
+        return HStack {
             HStack {
                 Text(DataLocalizer.localize(path: "APP.GENERAL.TIME"))
                 Spacer()
@@ -184,6 +183,7 @@ public class dydxPortfolioFundingViewModel: PlatformListViewModel {
         .padding(.bottom, 16)
         .themeFont(fontSize: .small)
         .themeColor(foreground: .textTertiary)
+        .wrappedViewModel
     }
 }
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioOrdersView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioOrdersView.swift
@@ -181,13 +181,14 @@ public class dydxPortfolioOrderItemViewModel: PlatformViewModel {
 }
 
 public class dydxPortfolioOrdersViewModel: PlatformListViewModel {
-    @Published public var placeholderText: String? {
-        didSet {
-            _placeholder.text = placeholderText
-        }
-    }
+    @Published public var shouldDisplayIsolatedOrdersWarning: Bool = false
+    @Published public var placeholderText: String?
 
-    private let _placeholder = PlaceholderViewModel()
+    public override var placeholder: PlatformViewModel? {
+        let vm = PlaceholderViewModel()
+        vm.text = placeholderText
+        return vm
+    }
 
     public init(items: [PlatformViewModel] = [], contentChanged: (() -> Void)? = nil) {
         super.init(items: items,
@@ -195,10 +196,6 @@ public class dydxPortfolioOrdersViewModel: PlatformListViewModel {
                    firstListItemTopSeparator: true,
                    lastListItemBottomSeparator: true,
                    contentChanged: contentChanged)
-        self.placeholder = _placeholder
-        self.header = createHeader().wrappedViewModel
-        self.footer = createFooter().wrappedViewModel
-        self.width = UIScreen.main.bounds.width - 16
     }
 
     public static var previewValue: dydxPortfolioOrdersViewModel {
@@ -210,8 +207,9 @@ public class dydxPortfolioOrdersViewModel: PlatformListViewModel {
         return vm
     }
 
-    private func createHeader() -> some View {
-        HStack {
+    public override var header: PlatformViewModel? {
+        guard items.count > 0 else { return nil }
+        return HStack {
             Text(DataLocalizer.localize(path: "APP.GENERAL.STATUS_FILL"))
             Spacer()
             Text(DataLocalizer.localize(path: "APP.GENERAL.PRICE_TYPE"))
@@ -220,16 +218,19 @@ public class dydxPortfolioOrdersViewModel: PlatformListViewModel {
         .padding(.bottom, 16)
         .themeFont(fontSize: .small)
         .themeColor(foreground: .textTertiary)
+        .wrappedViewModel
     }
 
-    private func createFooter() -> some View {
-        Text(localizerPathKey: "APP.GENERAL.ISOLATED_POSITION_ORDERS_COMING_SOON")
+    public override var footer: PlatformViewModel? {
+        guard shouldDisplayIsolatedOrdersWarning else { return nil }
+        return Text(localizerPathKey: "APP.GENERAL.ISOLATED_POSITION_ORDERS_COMING_SOON")
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 16)
                 .themeFont(fontSize: .small)
                 .themeColor(foreground: .textTertiary)
                 .padding(.top, 12)
                 .padding(.bottom, 16)
+                .wrappedViewModel
     }
 }
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -320,21 +320,26 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
 }
 
 public class dydxPortfolioPositionsViewModel: PlatformListViewModel {
-    @Published public var placeholderText: String? {
-        didSet {
-            _placeholder.text = placeholderText
-        }
+    // TODO: remove once isolated markets is supported and force released
+    @Published public var shouldDisplayIsolatedPositionsWarning: Bool = false
+    @Published public var placeholderText: String?
+
+    public override var placeholder: PlatformViewModel? {
+        let vm = PlaceholderViewModel()
+        vm.text = placeholderText
+        return vm
     }
 
-    private let _placeholder = PlaceholderViewModel()
-
-    public override init(items: [PlatformViewModel] = [], header: PlatformViewModel? = nil, placeholder: PlatformViewModel? = nil, intraItemSeparator: Bool = false, firstListItemTopSeparator: Bool = false, lastListItemBottomSeparator: Bool = false, contentChanged: (() -> Void)? = nil) {
-        super.init(items: items, header: header, placeholder: placeholder, intraItemSeparator: intraItemSeparator, firstListItemTopSeparator: firstListItemTopSeparator, lastListItemBottomSeparator: lastListItemBottomSeparator, contentChanged: contentChanged)
-        self.placeholder = _placeholder
-        if dydxBoolFeatureFlag.enable_isolated_margins.isEnabled == false {
-            self.header = createHeader().wrappedViewModel
-        }
-        self.footer = createFooter().wrappedViewModel
+    public override init(items: [PlatformViewModel] = [],
+                         intraItemSeparator: Bool = false,
+                         firstListItemTopSeparator: Bool = false,
+                         lastListItemBottomSeparator: Bool = false,
+                         contentChanged: (() -> Void)? = nil) {
+        super.init(items: items,
+                   intraItemSeparator: intraItemSeparator,
+                   firstListItemTopSeparator: firstListItemTopSeparator,
+                   lastListItemBottomSeparator: lastListItemBottomSeparator,
+                   contentChanged: contentChanged)
         self.width = UIScreen.main.bounds.width - 32
     }
 
@@ -347,8 +352,9 @@ public class dydxPortfolioPositionsViewModel: PlatformListViewModel {
         return vm
     }
 
-    private func createHeader() -> some View {
-        HStack {
+    public override var header: PlatformViewModel? {
+        guard dydxBoolFeatureFlag.enable_isolated_margins.isEnabled == false, !items.isEmpty else { return nil }
+        return HStack {
             Text(DataLocalizer.localize(path: "APP.GENERAL.DETAILS"))
             Spacer()
             Text(DataLocalizer.localize(path: "APP.GENERAL.INDEX_ENTRY"))
@@ -362,16 +368,19 @@ public class dydxPortfolioPositionsViewModel: PlatformListViewModel {
         .padding(.horizontal, 16)
         .themeFont(fontSize: .small)
         .themeColor(foreground: .textTertiary)
+        .wrappedViewModel
     }
 
-    private func createFooter() -> some View {
-        Text(localizerPathKey: "APP.GENERAL.ISOLATED_POSITIONS_COMING_SOON")
+    public override var footer: PlatformViewModel? {
+        guard shouldDisplayIsolatedPositionsWarning else { return nil }
+        return Text(localizerPathKey: "APP.GENERAL.ISOLATED_POSITIONS_COMING_SOON")
             .multilineTextAlignment(.center)
             .padding(.horizontal, 16)
             .themeFont(fontSize: .small)
             .themeColor(foreground: .textTertiary)
             .padding(.top, 12)
             .padding(.bottom, 16)
+            .wrappedViewModel
     }
 }
 

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioTransfersViewModel.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioTransfersViewModel.swift
@@ -10,17 +10,16 @@ import PlatformUI
 import Utilities
 
 public class dydxPortfolioTransfersViewModel: PlatformListViewModel {
-    @Published public var placeholderText: String? {
-        didSet {
-            _placeholder.text = placeholderText
-        }
-    }
+    @Published public var placeholderText: String?
 
-    private let _placeholder = PlaceholderViewModel()
+    public override var placeholder: PlatformViewModel? {
+        let vm = PlaceholderViewModel()
+        vm.text = placeholderText
+        return vm
+    }
 
     public init(items: [PlatformViewModel] = [], contentChanged: (() -> Void)? = nil) {
         super.init(items: items,
-                   placeholder: _placeholder,
                    intraItemSeparator: true,
                    firstListItemTopSeparator: true,
                    lastListItemBottomSeparator: true,


### PR DESCRIPTION
## Description / Intuition
previously, isolated markets warning was always being shown. Now there is conditional logic to display it. See [conversation](https://dydx-team.slack.com/archives/C0630UM6JMD/p1716994725655049?thread_ts=1714768786.322769&cid=C0630UM6JMD)

- do no display isolated markets warning when not onboarded
- display warning (footer) for empty state as well
- replaces the `contentChanged` approach with overridable header/footer properties
-  see video for (1) no wallet state (2) wallet connected, empty state (3) open position state
- display trigger price for trigger market orders instead of `MARKET` (see [conversation](https://dydx-team.slack.com/archives/C0630UM6JMD/p1716928867569249))

<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/da61f43b-991e-4b6e-ab1f-56b7718bd8e0"> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/8fd19593-6772-4577-be03-915d245a9203" width=50%> |


<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
