### PR TITLE
conditionally display memo warning for non-usdc

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
@@ -159,6 +159,7 @@ class dydxTransferOutViewPresenter: HostedViewPresenter<dydxTransferOutViewModel
 
         viewModel?.addressInput?.value = transferInput.address
 
+        viewModel?.memoBox?.shouldDisplayWarningWhenEmpty = transferInput.token != dydxTokenConstants.usdcTokenKey
         viewModel?.memoBox?.value = transferInput.memo
     }
 

--- a/dydx/dydxViews/dydxViews/_v4/Transfer/Components/MemoBox.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Transfer/Components/MemoBox.swift
@@ -12,6 +12,7 @@ import dydxFormatter
 
 public class MemoBoxModel: PlatformTextInputViewModel {
     @Published public var pasteAction: (() -> Void)?
+    @Published public var shouldDisplayWarningWhenEmpty: Bool = false
 
     public init(onEdited: ((String?) -> Void)?) {
         super.init(label: DataLocalizer.localize(path: "APP.GENERAL.MEMO"),
@@ -20,7 +21,7 @@ public class MemoBoxModel: PlatformTextInputViewModel {
     }
 
     private var memoWarning: InlineAlertViewModel? {
-        guard value?.isEmpty != false else { return nil }
+        guard value?.isEmpty != false && shouldDisplayWarningWhenEmpty else { return nil }
         return InlineAlertViewModel(.init(title: nil,
                                    body: DataLocalizer.localize(path: "ERRORS.TRANSFER_MODAL.TRANSFER_WITHOUT_MEMO"),
                                    level: .warning))


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket: [MOB-536 : \[iOS\] Add memo for token transfer (non-USDC only)](https://linear.app/dydx/issue/MOB-536/[ios]-add-memo-for-token-transfer-non-usdc-only)


<br/>

## Description / Intuition
- only display warning if non-usdc is selected




<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <video src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/734c2067-0153-45e4-a3ef-bbf6ef4f26a2"> |


### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
