### PR TITLE
isolated markets integration pt. 2

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
@@ -307,7 +307,7 @@
                     "destination":"dydxPresenters.dydxTakeProfitStopLossViewBuilder",
                     "presentation":"prompt"
                 },
-                "/trade/margin_type":{
+                "/trade/margin_mode":{
                     "destination":"dydxPresenters.dydxMarginModeViewBuilder",
                     "presentation":"half"
                 },

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/Margin/dydxMarginModeViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/Margin/dydxMarginModeViewBuilder.swift
@@ -76,8 +76,10 @@ private class dydxMarginModeViewPresenter: HostedViewPresenter<dydxMarginModeVie
         case .cross:
             crossItemViewModel.isSelected = true
             isolatedItemViewModel.isSelected = false
+            isolatedItemViewModel.isDisabled = tradeInput.options?.marginModeOptions == nil
         case .isolated:
             crossItemViewModel.isSelected = false
+            crossItemViewModel.isDisabled = tradeInput.options?.marginModeOptions == nil
             isolatedItemViewModel.isSelected = true
         default:
             assertionFailure("should have margin mode")

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/Margin/dydxMarginModeViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/Margin/dydxMarginModeViewBuilder.swift
@@ -24,7 +24,7 @@ public class dydxMarginModeViewBuilder: NSObject, ObjectBuilderProtocol {
 
 private class dydxMarginModeViewController: HostingViewController<PlatformView, dydxMarginModeViewModel> {
     override public func arrive(to request: RoutingRequest?, animated: Bool) -> Bool {
-        if request?.path == "/trade/margin_type" {
+        if request?.path == "/trade/margin_mode" {
             return true
         }
         return false
@@ -64,15 +64,15 @@ private class dydxMarginModeViewPresenter: HostedViewPresenter<dydxMarginModeVie
         super.start()
 
         AbacusStateManager.shared.state.tradeInput
-            .compactMap(\.?.marginMode)
-            .sink {[weak self] mode in
-                self?.updateMarginMode(mode: mode)
+            .compactMap { $0 }
+            .sink {[weak self] input in
+                self?.update(tradeInput: input)
             }
             .store(in: &subscriptions)
     }
 
-    private func updateMarginMode(mode: MarginMode) {
-        switch mode {
+    private func update(tradeInput: Abacus.TradeInput) {
+        switch tradeInput.marginMode {
         case .cross:
             crossItemViewModel.isSelected = true
             isolatedItemViewModel.isSelected = false

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/Margin/dydxTargetLeverageViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/Margin/dydxTargetLeverageViewBuilder.swift
@@ -86,8 +86,6 @@ private class dydxTargetLeverageViewPresenter: HostedViewPresenter<dydxTargetLev
     override func start() {
         super.start()
 
-        // TODO: Fix...? tradeInput?.targetLeverage is nil for now
-
         Publishers.CombineLatest(AbacusStateManager.shared.state.configsAndAssetMap,
                        AbacusStateManager.shared.state.tradeInput)
             .compactMap { $0 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputMarginViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputMarginViewPresenter.swift
@@ -44,7 +44,8 @@ class dydxTradeInputMarginViewPresenter: HostedViewPresenter<dydxTradeInputMargi
     }
 
     private func update(withTradeInput tradeInput: Abacus.TradeInput) {
+        viewModel?.shouldDisplayTargetLeverage = tradeInput.marginMode == MarginMode.isolated
         viewModel?.marginMode = DataLocalizer.localize(path: "APP.GENERAL.\(tradeInput.marginMode.rawValue)")
-        viewModel?.marginLeverage = "\(tradeInput.targetLeverage)×"
+        viewModel?.targetLeverage = "\(tradeInput.targetLeverage)"
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputMarginViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputMarginViewPresenter.swift
@@ -36,7 +36,7 @@ class dydxTradeInputMarginViewPresenter: HostedViewPresenter<dydxTradeInputMargi
             .store(in: &subscriptions)
 
         viewModel?.marginModeAction = {
-            Router.shared?.navigate(to: RoutingRequest(path: "/trade/margin_type"), animated: true, completion: nil)
+            Router.shared?.navigate(to: RoutingRequest(path: "/trade/margin_mode"), animated: true, completion: nil)
         }
         viewModel?.marginLeverageAction = {
             Router.shared?.navigate(to: RoutingRequest(path: "/trade/target_leverage"), animated: true, completion: nil)
@@ -44,7 +44,7 @@ class dydxTradeInputMarginViewPresenter: HostedViewPresenter<dydxTradeInputMargi
     }
 
     private func update(withTradeInput tradeInput: Abacus.TradeInput) {
-        viewModel?.shouldDisplayTargetLeverage = tradeInput.marginMode == MarginMode.isolated
+        viewModel?.shouldDisplayTargetLeverage = tradeInput.options?.needsTargetLeverage == true
         viewModel?.marginMode = DataLocalizer.localize(path: "APP.GENERAL.\(tradeInput.marginMode.rawValue)")
         viewModel?.targetLeverage = "\(tradeInput.targetLeverage)"
     }

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -153,7 +153,7 @@ public final class AbacusStateManager: NSObject {
                 // For debugging only
                 deployment = "DEV"
                 appConfigs = AppConfigs.companion.forAppDebug
-                appConfigsV2 = AppConfigsV2.companion.forAppDebug
+                appConfigsV2 = dydxBoolFeatureFlag.enable_isolated_margins.isEnabled ? AppConfigsV2.companion.forAppWithIsolatedMargins : AppConfigsV2.companion.forAppDebug
             case .jailBroken:
                 deployment = "TESTNET"
                 appConfigs = AppConfigs.companion.forApp

--- a/dydx/dydxViews/dydxViews/_v4/Trade/Margin/dydxMarginModeView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Trade/Margin/dydxMarginModeView.swift
@@ -13,6 +13,7 @@ import Utilities
 public class dydxMarginModeItemViewModel: PlatformViewModel {
     @Published public var title: String?
     @Published public var detail: String?
+    @Published public var isDisabled: Bool = false
     @Published public var isSelected: Bool = false
     @Published public var selectedAction: (() -> Void)?
 
@@ -33,14 +34,16 @@ public class dydxMarginModeItemViewModel: PlatformViewModel {
                 HStack {
                     Text(self.title ?? "")
                         .themeFont(fontSize: .medium)
-                        .themeColor(foreground: .textPrimary)
+                        .themeColor(foreground: self.isDisabled ? .textTertiary : .textPrimary)
 
                     Spacer()
 
-                    if self.isSelected {
-                        self.createSelectedCheckmark(parentStyle: style)
-                    } else {
-                        self.createUnselectedCheckmark(parentStyle: style)
+                    if !self.isDisabled {
+                        if self.isSelected {
+                            self.createSelectedCheckmark(parentStyle: style)
+                        } else {
+                            self.createUnselectedCheckmark(parentStyle: style)
+                        }
                     }
                 }
 
@@ -52,11 +55,9 @@ public class dydxMarginModeItemViewModel: PlatformViewModel {
                 .padding(16)
                 .leftAligned()
                 .themeColor(background: self.isSelected ? ThemeColor.SemanticColor.layer1 : ThemeColor.SemanticColor.layer3)
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius)
-                        .strokeBorder(self.isSelected ? ThemeColor.SemanticColor.colorPurple.color : ThemeColor.SemanticColor.textTertiary.color, lineWidth: 1)
-                )
-                .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+                .borderAndClip(style: .cornerRadius(8),
+                               borderColor: isSelected ? .colorPurple : isDisabled ? .textTertiary : .layer7,
+                               lineWidth: isSelected ? 2 : 1)
                 .wrappedViewModel
 
             return AnyView(
@@ -64,6 +65,7 @@ public class dydxMarginModeItemViewModel: PlatformViewModel {
                                         type: PlatformButtonType.iconType,
                                         action: self.selectedAction ?? {})
                     .createView(parentStyle: style)
+                    .disabled(isDisabled)
             )
         }
     }

--- a/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputMarginView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Trade/TradeInput/Components/TradeInputFields/dydxTradeInputMarginView.swift
@@ -11,66 +11,86 @@ import PlatformUI
 import Utilities
 
 public class dydxTradeInputMarginViewModel: PlatformViewModel {
+    @Published public var shouldDisplayTargetLeverage: Bool = false
     @Published public var marginMode: String?
-    @Published public var marginLeverage: String?
+    @Published public var targetLeverage: String?
     @Published public var marginModeAction: (() -> Void)?
     @Published public var marginLeverageAction: (() -> Void)?
+
+    private let borderRadius: CGFloat = 12
+    private let optionHeight: CGFloat = 44
 
     public init() { }
 
     public static var previewValue: dydxTradeInputMarginViewModel {
         let vm = dydxTradeInputMarginViewModel()
-        vm.marginLeverage = "2×"
+        vm.targetLeverage = "2×"
         return vm
     }
 
+    private var marginModeView: some View {
+        let content = HStack(spacing: 0) {
+            Spacer()
+            HStack(spacing: 4) {
+                Text(self.marginMode ?? "")
+                    .themeFont(fontSize: .medium)
+                    .themeColor(foreground: .textPrimary)
+                Text("⏵")
+                    .themeFont(fontSize: .smaller)
+                    .themeColor(foreground: .textTertiary)
+            }
+            Spacer()
+        }
+            .wrappedViewModel
+
+        return PlatformButtonViewModel(
+            content: content,
+            type: .iconType,
+            state: .secondary) { [weak self] in
+            self?.marginModeAction?()
+        }
+        .createView()
+    }
+
+    private var targetLeverageView: PlatformView? {
+        guard shouldDisplayTargetLeverage else { return nil }
+        let content = HStack(spacing: 2) {
+            Text(self.targetLeverage ?? "")
+                .themeFont(fontSize: .medium)
+                .themeColor(foreground: .textPrimary)
+            Text("×")
+                .themeFont(fontType: .plus, fontSize: .smaller)
+                .themeColor(foreground: .textTertiary)
+        }
+            .padding(.horizontal, 16)
+            .wrappedViewModel
+
+        return PlatformButtonViewModel(
+            content: content,
+            type: .iconType,
+            state: .secondary
+        ) { [weak self] in
+            self?.marginLeverageAction?()
+        }
+        .createView()
+    }
+
     public override func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformView {
-        PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] style  in
+        PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] _  in
             guard let self = self else { return AnyView(PlatformView.nilView) }
 
             return AnyView(
                 HStack(spacing: 8) {
-                    let marginModeText =
-                        self.createButtonContent(parentStyle: style,
-                                                 text: self.marginMode ?? "")
-                            .wrappedViewModel
-                    PlatformButtonViewModel(content: marginModeText,
-                                            type: PlatformButtonType.iconType) { [weak self] in
-                        self?.marginModeAction?()
+                    Group {
+                        self.marginModeView
+                        self.targetLeverageView
                     }
-                    .createView(parentStyle: style)
-
-                    let marginLeverageText =
-                        self.createButtonContent(parentStyle: style,
-                                                 text: self.marginLeverage ?? "")
-                        .wrappedViewModel
-                    PlatformButtonViewModel(content: marginLeverageText,
-                                            type: PlatformButtonType.iconType) { [weak self] in
-                        self?.marginLeverageAction?()
-                    }
-                    .createView(parentStyle: style)
-                    .frame(width: 60)
+                    .frame(height: self.optionHeight)
+                    .themeColor(background: .layer5)
+                    .borderAndClip(style: .cornerRadius(self.borderRadius), borderColor: .layer7)
                 }
             )
         }
-    }
-
-    private let optionHeight: CGFloat = 44
-    private let cornerRadius: CGFloat = 12
-    private let optionPadding: CGFloat = 3
-
-    private func createButtonContent(parentStyle: ThemeStyle, text: String) -> some View {
-        Text(text)
-            .themeFont(fontSize: .medium)
-            .themeColor(foreground: .textPrimary)
-            .frame(height: optionHeight)
-            .frame(minWidth: 0, maxWidth: .infinity)
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .strokeBorder(ThemeColor.SemanticColor.textTertiary.color, lineWidth: 1)
-            )
-            .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
-            .padding(optionPadding)
     }
 }
 


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Figma Design: https://www.figma.com/design/mKevZOfE9nj6MZpiolKYW1/dYdX-%E2%80%BA-Mobile?node-id=5956-14595&t=202A2LqIHvbrg6aR-4




<br/>

## Description / Intuition
- adds abacus app config for isolated markets (behind feature flag)
- behind isolated markets feature flag - conditionally use `groupedSubaccounts` or `subaccounts`
- disable margin mode selection when open order or position `needsMarginMode == false`
- conditionally display target leverage depending on margin mode




<br/>

## Before/After Screenshots or Videos

| Desc | After |
|--------|-------|
| displaying both isolated and cross positions | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/806790c5-2a8b-405d-839d-7aa74118fc19"> |
| isolated margin buttons | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/b99874f7-98d0-4e9a-8c14-b7a46aecb06d"> |
| isolated enabled (cross open position or order) | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/3f77db3c-c2d4-46d7-b4fe-80a6cba9b172"> |
| cross margin buttons | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/b6255981-a5ee-4fb8-b5ce-f28a52778561"> |
|  cross enabled (cross open position or order)  | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/2ee3f5c4-3704-4396-908e-64030f427904"> |
| both enabled (no open position or order) | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/43b6afb2-9102-4c93-8cd7-352cf44f0724"> |



<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
