### PR TITLE
MOB-544 Add preference setting for gas payment type

### DIFF
--- a/PlatformUIJedio/PlatformUIJedio/Presenters/FieldSettingsViewPresenter.swift
+++ b/PlatformUIJedio/PlatformUIJedio/Presenters/FieldSettingsViewPresenter.swift
@@ -33,8 +33,8 @@ open class FieldSettingsViewPresenter: BaseSettingsViewPresenter {
         listModel.width = UIScreen.main.bounds.width - 16
         let options: [[String: Any]]? = fieldInput?.options
         listModel.items = (options ?? []).compactMap { option in
-            guard let text = parser.asString(option["text"]),
-                  let value = parser.asString(option["value"]) else {
+            guard let text = textForOption(option: option),
+                  let value = valueForOption(option: option) else {
                 return nil
             }
             
@@ -62,6 +62,14 @@ open class FieldSettingsViewPresenter: BaseSettingsViewPresenter {
     }
     
     open func onOptionSelected(option: [String: Any], changed: Bool) {
+    }
+    
+    open func textForOption(option:  [String: Any]) -> String? {
+        parser.asString(option["text"])
+    }
+    
+    open func valueForOption(option:  [String: Any]) -> String? {
+        parser.asString(option["value"])
     }
 
     private func findInput(fieldName: String) -> FieldInput? {

--- a/dydx/dydxPresenters/dydxPresenters.xcodeproj/project.pbxproj
+++ b/dydx/dydxPresenters/dydxPresenters.xcodeproj/project.pbxproj
@@ -117,6 +117,9 @@
 		02E7B3B129D79A4400D6626D /* v4-native-client.js in Resources */ = {isa = PBXBuildFile; fileRef = 02E7B38729D79A4400D6626D /* v4-native-client.js */; };
 		02E90C5A29D62719004E2311 /* dydxFeatureFlagsViewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E90C5929D62719004E2311 /* dydxFeatureFlagsViewBuilder.swift */; };
 		02EF485629F732C600C97746 /* dydxFavoriteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF485529F732C600C97746 /* dydxFavoriteStore.swift */; };
+		02F543B22C17ABBB000924E4 /* dydxGasTokenViewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F543B12C17ABBB000924E4 /* dydxGasTokenViewBuilder.swift */; };
+		02F543B42C17AD6A000924E4 /* settings_gas_token.json in Resources */ = {isa = PBXBuildFile; fileRef = 02F543B32C17AD6A000924E4 /* settings_gas_token.json */; };
+		02F543B62C17B792000924E4 /* dydxGasTokenWorker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F543B52C17B792000924E4 /* dydxGasTokenWorker.swift */; };
 		02F6E71F2A8293270018F00C /* dydxProfileFeesViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F6E71E2A8293270018F00C /* dydxProfileFeesViewPresenter.swift */; };
 		02F700FE29EA0FD9004DEB5E /* dydxReceiptPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F700FD29EA0FD9004DEB5E /* dydxReceiptPresenter.swift */; };
 		02F7010029EA165F004DEB5E /* dydxTransferReceiptViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F700FF29EA165F004DEB5E /* dydxTransferReceiptViewPresenter.swift */; };
@@ -498,6 +501,9 @@
 		02E7DD9128CFB30000727949 /* dydxStateManager.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = dydxStateManager.xcodeproj; path = ../dydxStateManager/dydxStateManager.xcodeproj; sourceTree = "<group>"; };
 		02E90C5929D62719004E2311 /* dydxFeatureFlagsViewBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxFeatureFlagsViewBuilder.swift; sourceTree = "<group>"; };
 		02EF485529F732C600C97746 /* dydxFavoriteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxFavoriteStore.swift; sourceTree = "<group>"; };
+		02F543B12C17ABBB000924E4 /* dydxGasTokenViewBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxGasTokenViewBuilder.swift; sourceTree = "<group>"; };
+		02F543B32C17AD6A000924E4 /* settings_gas_token.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = settings_gas_token.json; sourceTree = "<group>"; };
+		02F543B52C17B792000924E4 /* dydxGasTokenWorker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxGasTokenWorker.swift; sourceTree = "<group>"; };
 		02F6E71E2A8293270018F00C /* dydxProfileFeesViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxProfileFeesViewPresenter.swift; sourceTree = "<group>"; };
 		02F700FD29EA0FD9004DEB5E /* dydxReceiptPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxReceiptPresenter.swift; sourceTree = "<group>"; };
 		02F700FF29EA165F004DEB5E /* dydxTransferReceiptViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = dydxTransferReceiptViewPresenter.swift; sourceTree = "<group>"; };
@@ -930,6 +936,7 @@
 		0258BA1E299294A90098E1BE /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				02F543B02C17AAD7000924E4 /* GasToken */,
 				278EA5622BB61094007A0E17 /* Notifications */,
 				277E90052B1EA093005CCBCB /* TradingRewards */,
 				02B27A3B2AE8BC6B00A995EC /* Help */,
@@ -976,6 +983,7 @@
 			isa = PBXGroup;
 			children = (
 				64487FFE2AA248340068DD87 /* dydxAlertsWorker.swift */,
+				02F543B52C17B792000924E4 /* dydxGasTokenWorker.swift */,
 				020EB696299D36AD00E8026B /* dydxApiStatusWorker.swift */,
 				02B6CE742A7087A700C5F088 /* dydxTransferSubaccountWorker.swift */,
 				27351D442AC4A67900E4A563 /* dydxRestrictionsWorker.swift */,
@@ -1275,6 +1283,7 @@
 				02E7B37C29D79A4400D6626D /* settings_notifications.json */,
 				0295392629FB28B7009026E3 /* settings_theme.json */,
 				2741E3632A68787A000FA190 /* settings_direction_color_preference.json */,
+				02F543B32C17AD6A000924E4 /* settings_gas_token.json */,
 				0279656929D795E7004DEB20 /* routing_swiftui.json */,
 				0279655B29D795E7004DEB20 /* tabs_v4.json */,
 				02E7B38729D79A4400D6626D /* v4-native-client.js */,
@@ -1300,6 +1309,14 @@
 				02E90C5929D62719004E2311 /* dydxFeatureFlagsViewBuilder.swift */,
 			);
 			path = FeatureFlags;
+			sourceTree = "<group>";
+		};
+		02F543B02C17AAD7000924E4 /* GasToken */ = {
+			isa = PBXGroup;
+			children = (
+				02F543B12C17ABBB000924E4 /* dydxGasTokenViewBuilder.swift */,
+			);
+			path = GasToken;
 			sourceTree = "<group>";
 		};
 		02F958152A1BDEEF00828F9A /* KeyExport */ = {
@@ -1807,6 +1824,7 @@
 				02E7B3A729D79A4400D6626D /* debug_default.json in Resources */,
 				02E7B39929D79A4400D6626D /* test.js in Resources */,
 				02E7B39A29D79A4400D6626D /* settings.json in Resources */,
+				02F543B42C17AD6A000924E4 /* settings_gas_token.json in Resources */,
 				0279656A29D795E8004DEB20 /* tabs_v4.json in Resources */,
 				02E7B3A629D79A4400D6626D /* settings_notifications.json in Resources */,
 				02E7B39C29D79A4400D6626D /* debug.json in Resources */,
@@ -1970,6 +1988,7 @@
 				02860A9F29C15E760079E644 /* dydxOnboardScanViewBuilder.swift in Sources */,
 				277E90332B1FAE9A005CCBCB /* dydxRewardsHelpViewPresenter.swift in Sources */,
 				02FAFA5C29D4E08E001A0903 /* dydxDebugViewBuilder.swift in Sources */,
+				02F543B22C17ABBB000924E4 /* dydxGasTokenViewBuilder.swift in Sources */,
 				02F700FE29EA0FD9004DEB5E /* dydxReceiptPresenter.swift in Sources */,
 				027E1EF829CA27CD0098666F /* dydxSettingsLandingViewBuilder.swift in Sources */,
 				020DBF1E29E092C00068AAA6 /* dydxTransferDepositViewPresenter.swift in Sources */,
@@ -1978,6 +1997,7 @@
 				021B68B12AD9B86600C5C3BF /* dydxSecurityViewPresenter.swift in Sources */,
 				024B43A229812DC700E35D54 /* dydxValidationViewPresenter.swift in Sources */,
 				024B44D42982D24A00E35D54 /* dydxTradeStatusViewBuilder.swift in Sources */,
+				02F543B62C17B792000924E4 /* dydxGasTokenWorker.swift in Sources */,
 				0279DE792BEC472600F9ECF8 /* dydxAdjustMarginInputViewBuilder.swift in Sources */,
 				6496DC3E295E122B00174CE7 /* dydxTradeInputViewBuilder.swift in Sources */,
 				64A4DB9529664803008D8E20 /* dydxTradeInputEditPresenter.swift in Sources */,

--- a/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/routing_swiftui.json
@@ -280,6 +280,9 @@
                 "/settings/direction_color_preference":{
                     "destination":"dydxPresenters.dydxDirectionColorPreferenceViewBuilder"
                 },
+                "/settings/gas_token":{
+                    "destination":"dydxPresenters.dydxGasTokenViewBuilder"
+                },
                 "/settings/status": {
                     "destination":"dydxPresenters.dydxSystemStatusBuilder"
                 },

--- a/dydx/dydxPresenters/dydxPresenters/_Features/settings.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/settings.json
@@ -43,6 +43,14 @@
             },
             {
                 "title" : {
+                    "text" : "APP.GENERAL.PAY_GAS_WITH"
+                },
+                "link" : {
+                    "text" : "/settings/gas_token"
+                }
+            },
+            {
+                "title" : {
                     "text" : "APP.HELP_MODAL.PROVIDE_FEEDBACK"
                 },
                 "link" : {

--- a/dydx/dydxPresenters/dydxPresenters/_Features/settings_debug.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/settings_debug.json
@@ -67,6 +67,14 @@
             },
             {
                 "title" : {
+                    "text" : "APP.GENERAL.PAY_GAS_WITH"
+                },
+                "link" : {
+                    "text" : "/settings/gas_token"
+                }
+            },
+            {
+                "title" : {
                     "text" : "Debug Theme Viewer"
                 },
                 "link" : {

--- a/dydx/dydxPresenters/dydxPresenters/_Features/settings_gas_token.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/settings_gas_token.json
@@ -1,0 +1,26 @@
+[
+    {
+        "input":"1",
+        "fields":[
+            {
+                "title":{
+                    "text":"APP.GENERAL.PAY_GAS_WITH"
+                },
+                "field":{
+                    "field":"gas_token",
+                    "type":"text",
+                    "options":[
+                        {
+                            "text":"USDC",
+                            "value":"USDC"
+                        },
+                        {
+                            "text":"NATIVE",
+                            "value":"NATIVE"
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+]

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxGasTokenWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxGasTokenWorker.swift
@@ -1,0 +1,26 @@
+//
+//  dydxGasTokenWorker.swift
+//  dydxPresenters
+//
+//  Created by Rui Huang on 10/06/2024.
+//
+
+import Abacus
+import Combine
+import dydxStateManager
+import ParticlesKit
+import RoutingKit
+import Utilities
+
+public final class dydxGasTokenWorker: BaseWorker {
+
+    public override func start() {
+        super.start()
+
+        // set the gas token to the user preference
+        if let tokenName = SettingsStore.shared?.gasToken,
+            let token = GasToken.from(tokenName: tokenName) {
+            AbacusStateManager.shared.setGasToken(token: token)
+        }
+    }
+}

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/dydxGlobalWorkers.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/dydxGlobalWorkers.swift
@@ -17,7 +17,8 @@ public final class dydxGlobalWorkers: BaseWorker {
         dydxRestrictionsWorker(),
         dydxCarteraConfigWorker(),
         dydxUpdateWorker(),
-        dydxRatingsWorker()
+        dydxRatingsWorker(),
+        dydxGasTokenWorker()
     ]
 
     override public func start() {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/KeyValueStoreProtocolStore+Ext.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/KeyValueStoreProtocolStore+Ext.swift
@@ -14,6 +14,7 @@ public enum dydxSettingsStoreKey: String, CaseIterable {
     case v4Theme = "v4_theme"
     case directionColorPreference = "direction_color_preference"
     case shouldDisplayInAppNotifications = "should_display_in_app_notifications"
+    case gasToken = "gas_token"
 
     public var defaultValue: Any? {
         switch self {
@@ -21,6 +22,7 @@ public enum dydxSettingsStoreKey: String, CaseIterable {
         case .v4Theme: return dydxThemeType.classicDark.rawValue
         case .directionColorPreference: return "green_is_up"
         case .shouldDisplayInAppNotifications: return true
+        case .gasToken: return "USDC"
         }
     }
 }
@@ -49,5 +51,9 @@ extension KeyValueStoreProtocol {
         SettingsStore.shared?.value(forKey: dydxSettingsStoreKey.shouldDisplayInAppNotifications.rawValue) as? Bool
         ?? dydxSettingsStoreKey.shouldDisplayInAppNotifications.defaultValue as? Bool
         ?? true
+    }
+
+    var gasToken: String? {
+        SettingsStore.shared?.value(forKey: dydxSettingsStoreKey.gasToken.rawValue) as? String ?? "USDC"
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileBalancesViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/Components/dydxProfileBalancesViewPresenter.swift
@@ -33,11 +33,11 @@ public class dydxProfileBalancesViewPresenter: HostedViewPresenter<dydxProfileBa
         super.start()
 
         let decimal = 4
-        let dydxTokenDenom = AbacusStateManager.shared.environment?.dydxTokenInfo?.denom
+        let nativeTokenDenom = AbacusStateManager.shared.environment?.nativeTokenInfo?.denom
         Publishers
             .CombineLatest(
-                AbacusStateManager.shared.state.accountBalance(of: dydxTokenDenom),
-                AbacusStateManager.shared.state.stakingBalance(of: dydxTokenDenom)
+                AbacusStateManager.shared.state.accountBalance(of: nativeTokenDenom),
+                AbacusStateManager.shared.state.stakingBalance(of: nativeTokenDenom)
             )
             .sink { [weak self] accountBalance, stakingBalance in
                 if let accountBalance = accountBalance {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/GasToken/dydxGasTokenViewBuilder.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/GasToken/dydxGasTokenViewBuilder.swift
@@ -1,0 +1,70 @@
+//
+//  dydxGasTokenViewBuilder.swift
+//  dydxPresenters
+//
+//  Created by Rui Huang on 10/06/2024.
+//  Copyright © 2024 dYdX Trading Inc. All rights reserved.
+//
+
+import SwiftUI
+import dydxViews
+import PlatformParticles
+import RoutingKit
+import ParticlesKit
+import PlatformUI
+import PlatformUIJedio
+import Utilities
+import dydxStateManager
+import Abacus
+
+public class dydxGasTokenViewBuilder: NSObject, ObjectBuilderProtocol {
+    public func build<T>() -> T? {
+        let presenter = dydxGasTokenViewPresenter()
+        let view = presenter.viewModel?.createView() ?? PlatformViewModel().createView()
+        let viewController = SettingsViewController(presenter: presenter, view: view, configuration: .default)
+        viewController.requestPath = "/settings/gas_token"
+        return viewController as? T
+    }
+}
+
+private class dydxGasTokenViewPresenter: FieldSettingsViewPresenter {
+    init() {
+        super.init(definitionFile: "settings_gas_token.json", fieldName: "gas_token", keyValueStore: SettingsStore.shared)
+
+        let header = SettingHeaderViewModel()
+        header.text = DataLocalizer.localize(path: "APP.GENERAL.PAY_GAS_WITH")
+        header.dismissAction = {
+            Router.shared?.navigate(to: RoutingRequest(path: "/action/dismiss"), animated: true, completion: nil)
+        }
+        viewModel?.headerViewModel = header
+    }
+
+    override func onOptionSelected(option: [String: Any], changed: Bool) {
+        if changed, let value = option["value"] as? String {
+            if let token = GasToken.from(tokenName: value) {
+                AbacusStateManager.shared.setGasToken(token: token)
+                Router.shared?.navigate(to: RoutingRequest(path: "/action/dismiss"), animated: true, completion: nil)
+            } else {
+                ErrorLogging.shared?.e(tag: "dydxGasTokenViewPresenter",
+                                       message: "Invalid token: \(value)")
+            }
+        }
+    }
+
+    override func textForOption(option: [String: Any]) -> String? {
+        GasTokenOptionTransformer().textForOption(option: option) ?? super.textForOption(option: option)
+    }
+}
+
+class GasTokenOptionTransformer: SettingsOptionTransformProtocol {
+    func textForOption(option: [String: Any]) -> String? {
+        switch option["value"] as? String {
+        case "USDC":
+            return AbacusStateManager.shared.environment?.usdcTokenInfo?.name
+        case "NATIVE":
+            return AbacusStateManager.shared.environment?.nativeTokenInfo?.name
+        default:
+            return nil
+        }
+    }
+}

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/Components/dydxTransferInputCtaButtonViewPresenter.swift
@@ -272,7 +272,7 @@ class dydxTransferInputCtaButtonViewPresenter: HostedViewPresenter<dydxTradeInpu
             AbacusStateManager.shared.state.transferInput,
             AbacusStateManager.shared.state.currentWallet,
             AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom),
-            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom)
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.nativeTokenInfo?.denom)
         )
         .prefix(1)
         .map {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Transfer/TransferOut/dydxTransferOutViewPresenter.swift
@@ -111,15 +111,15 @@ class dydxTransferOutViewPresenter: HostedViewPresenter<dydxTransferOutViewModel
             AbacusStateManager.shared.state.selectedSubaccount
                 .map(\.?.freeCollateral?.current)
                 .removeDuplicates(),
-            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.dydxTokenInfo?.denom)
+            AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.nativeTokenInfo?.denom)
         )
-            .sink { [weak self] selectedToken, freeCollateral, dydxTokenAmount in
+            .sink { [weak self] selectedToken, freeCollateral, nativeTokenAmount in
                 if selectedToken?.type == dydxTokenConstants.usdcTokenKey {
                     self?.viewModel?.amountBox?.maxAmount = freeCollateral?.doubleValue ?? 0
                     self?.viewModel?.amountBox?.tokenText = TokenTextViewModel(symbol: selectedToken?.localizedString ?? "")
                     self?.viewModel?.objectWillChange.send()
                 } else if selectedToken?.type == dydxTokenConstants.nativeTokenKey {
-                    self?.viewModel?.amountBox?.maxAmount = dydxTokenAmount ?? 0
+                    self?.viewModel?.amountBox?.maxAmount = nativeTokenAmount ?? 0
                     self?.viewModel?.amountBox?.tokenText = TokenTextViewModel(symbol: selectedToken?.localizedString ?? "")
                     self?.viewModel?.objectWillChange.send()
                 }

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -395,6 +395,10 @@ public final class AbacusStateManager: NSObject {
                                          requestId: requestId)
     }
 
+    public func setGasToken(token: GasToken) {
+        asyncStateManager.gasToken = token
+    }
+
     private static let storeKey = "AbacusStateManager.EnvState"
 }
 
@@ -494,7 +498,7 @@ public extension V4Environment {
         tokens["usdc"]
     }
 
-    var dydxTokenInfo: TokenInfo? {
+    var nativeTokenInfo: TokenInfo? {
         tokens["chain"]
     }
 }

--- a/dydx/dydxStateManager/dydxStateManager/Models+Ext.swift
+++ b/dydx/dydxStateManager/dydxStateManager/Models+Ext.swift
@@ -38,3 +38,13 @@ public extension OrderSide {
         }
     }
 }
+
+public extension GasToken {
+    static func from(tokenName: String) -> GasToken? {
+        switch tokenName {
+        case "USDC": return GasToken.usdc
+        case "NATIVE": return GasToken.native
+        default: return nil
+        }
+    }
+}


### PR DESCRIPTION


<br/>

## Description / Intuition
Add preference setting for gas payment type so user can select either USDC (default) or native token to pay gas.



<br/>

## Before/After Screenshots or Video


| Before | After |
|--------|-------|
| <video src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/102453770/a2389bd1-3939-4583-9d47-38d2f672c9f2"> |





<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
