### PR TITLE
handle short position case for displaying liquidation price, live-update position row items

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -20,7 +20,11 @@ _Provide a clear and concise description of the fix(es) or change(s) you made. I
 
 | Before | After |
 |--------|-------|
-| <img src=""> | <img src=""> |
+| <img src=""> | <img src="" width=60%> |
+| <img src=""> | <img src="" width=60%> |
+| <img src=""> | <img src="" width=60%> |
+| <img src=""> | <img src="" width=60%> |
+| <img src=""> | <img src="" width=60%> |
 | <video src=""> | <video src=""> |
 
 

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Portfolio/Components/dydxPortfolioPositionsViewPresenter.swift
@@ -21,9 +21,6 @@ protocol dydxPortfolioPositionsViewPresenterProtocol: HostedViewPresenterProtoco
 }
 
 class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPositionsViewModel>, dydxPortfolioPositionsViewPresenterProtocol {
-    private var positionsCache = [String: dydxPortfolioPositionItemViewModel]()
-    private var pendingPositionsCache = [String: dydxPortfolioPendingPositionsItemViewModel]()
-
     init(viewModel: dydxPortfolioPositionsViewModel?) {
         super.init()
 
@@ -57,12 +54,9 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
 
     private func updatePositions(positions: [SubaccountPosition], marketMap: [String: PerpetualMarket], assetMap: [String: Asset]) {
         let items: [dydxPortfolioPositionItemViewModel] = positions.compactMap { position -> dydxPortfolioPositionItemViewModel? in
-            let item = Self.createPositionViewModelItem(position: position,
+            Self.createPositionViewModelItem(position: position,
                                                         marketMap: marketMap,
-                                                        assetMap: assetMap,
-                                                        positionsCache: positionsCache)
-            positionsCache[position.assetId] = item
-            return item
+                                                        assetMap: assetMap)
         }
 
         self.viewModel?.positionItems = items
@@ -70,12 +64,9 @@ class dydxPortfolioPositionsViewPresenter: HostedViewPresenter<dydxPortfolioPosi
 
     private func updatePendingPositions(pendingPositions: [SubaccountPendingPosition], marketMap: [String: PerpetualMarket], assetMap: [String: Asset]) {
         let items: [dydxPortfolioPendingPositionsItemViewModel] = pendingPositions.compactMap { pendingPosition -> dydxPortfolioPendingPositionsItemViewModel? in
-            let item = Self.createPendingPositionsViewModelItem(pendingPosition: pendingPosition,
+            Self.createPendingPositionsViewModelItem(pendingPosition: pendingPosition,
                                                                 marketMap: marketMap,
-                                                                assetMap: assetMap,
-                                                                pendingPositionsCache: pendingPositionsCache)
-            pendingPositionsCache[pendingPosition.assetId] = item
-            return item
+                                                                assetMap: assetMap)
         }
 
         self.viewModel?.pendingPositionItems = items

--- a/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Portfolio/Components/Sections/dydxPortfolioPositionsView.swift
@@ -50,21 +50,21 @@ public class dydxPortfolioPositionItemViewModel: PlatformViewModel {
         self.handler = Handler(onTapAction: onTapAction, onMarginEditAction: onMarginEditAction)
     }
 
-    public var size: String?
-    public var token: TokenTextViewModel?
-    public var sideText = SideTextViewModel()
-    public var leverage: String?
-    public var leverageIcon: LeverageRiskModel?
-    public var indexPrice: String?
-    public var entryPrice: String?
-    public var unrealizedPnl: SignedAmountViewModel?
-    public var unrealizedPnlPercent: String = ""
-    public var marginValue: String = "--"
-    public var marginMode: String = "--"
-    public var isMarginAdjustable: Bool = false
-    public var logoUrl: URL?
-    public var gradientType: GradientType
-    public var handler: Handler?
+    @Published public var size: String?
+    @Published public var token: TokenTextViewModel?
+    @Published public var sideText = SideTextViewModel()
+    @Published public var leverage: String?
+    @Published public var leverageIcon: LeverageRiskModel?
+    @Published public var indexPrice: String?
+    @Published public var entryPrice: String?
+    @Published public var unrealizedPnl: SignedAmountViewModel?
+    @Published public var unrealizedPnlPercent: String = ""
+    @Published public var marginValue: String = "--"
+    @Published public var marginMode: String = "--"
+    @Published public var isMarginAdjustable: Bool = false
+    @Published public var logoUrl: URL?
+    @Published public var gradientType: GradientType
+    @Published public var handler: Handler?
 
     public static var previewValue: dydxPortfolioPositionItemViewModel {
         let item = dydxPortfolioPositionItemViewModel(


### PR DESCRIPTION
## Links (dYdX Internal Use Only)
Linear Ticket:
- [MOB-607 : ISO Bug - Adjust Margin liquidation price is wrong when position is short](https://linear.app/dydx/issue/MOB-607/iso-bug-adjust-margin-liquidation-price-is-wrong-when-position-is)
- [MOB-606 : ISO Bug - After Adding/Removing margin, position cards on portfolio do not show updated margin](https://linear.app/dydx/issue/MOB-606/iso-bug-after-addingremoving-margin-position-cards-on-portfolio-do-not)

Figma Design: https://www.figma.com/design/mKevZOfE9nj6MZpiolKYW1/dYdX-%E2%80%BA-Mobile?node-id=5956-16570&t=H5PO3Em25YfPWYom-4




<br/>

## Description / Intuition
- always show liq price for short positions
- remove caching of position row items (was causing issue for swiftui not detecting view element diffs)
- add width % to git PR template



<br/>

## Before/After Screenshots or Videos

| Before | After |
|--------|-------|
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/9e287bdc-3aa9-4fd0-939b-042ead6bc8c2" width=60%> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/1a458f92-f14a-4601-9bf2-34956619310a" width=60%> |
| <img src=""> | <img src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/f0e6b974-9cb1-4fa5-a15f-b605630868c0" width=60%> |
| <video src=""> | <video src="https://github.com/dydxprotocol/v4-native-ios/assets/149746839/3849a9d6-7a92-497c-8eac-0f7ea150c014"> |



<br/>

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
