### PR TITLE
return optional feature flag value value so configured default value takes effect

### DIFF
--- a/Utilities/Utilities/_Utils/_FeatureFlags/CompositeFeatureFlagsProvider.swift
+++ b/Utilities/Utilities/_Utils/_FeatureFlags/CompositeFeatureFlagsProvider.swift
@@ -57,9 +57,9 @@ public class CompositeFeatureFlagsProvider: NSObject & FeatureFlagsProtocol {
     public func isOn(feature: String) -> Bool? {
         switch Installation.source {
         case .appStore, .jailBroken:
-            return remote?.isOn(feature: feature) == true
+            return remote?.isOn(feature: feature)
         case .debug, .testFlight:
-            return local?.isOn(feature: feature) ?? remote?.isOn(feature: feature) ?? false
+            return local?.isOn(feature: feature) ?? remote?.isOn(feature: feature)
         }
     }
 


### PR DESCRIPTION
[context thread](https://dydx-team.slack.com/archives/C0738MMRX9C/p1723049001819769)

the `CompositeFeatureFlagsProvider` was forcing `false` as a default value, but default values should be decided later in the flow [here](https://github.com/dydxprotocol/v4-native-ios/blob/c2cd3da83e30fdf622895a45fbf5562004c693fd/dydx/dydxFormatter/dydxFormatter/_Utils/dydxFeatureFlag.swift#L40)