### PR TITLE
CLI-641: USDC sweep into subaccount does not work for fresh address

### DIFF
--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -23,7 +23,6 @@ final class dydxTransferSubaccountWorker: BaseWorker {
         AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom)
             .withLatestFrom(
                 AbacusStateManager.shared.state.walletState
-                .eraseToAnyPublisher()
             )
             .sink { [weak self] balance, walletState in
                 guard let balance, balance > dydxTransferSubaccountWorker.balanceRetainAmount else { return }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxTransferSubaccountWorker.swift
@@ -21,31 +21,19 @@ final class dydxTransferSubaccountWorker: BaseWorker {
         super.start()
 
         AbacusStateManager.shared.state.accountBalance(of: AbacusStateManager.shared.environment?.usdcTokenInfo?.denom)
-            .filter { value in
-                (value ?? 0) > dydxTransferSubaccountWorker.balanceRetainAmount
-            }
             .withLatestFrom(
-                Publishers.CombineLatest(
-                    AbacusStateManager.shared.state.walletState,
-                    AbacusStateManager.shared.state.selectedSubaccount
-                )
-                .map { (walletState: $0, subaccount: $1) }
+                AbacusStateManager.shared.state.walletState
                 .eraseToAnyPublisher()
             )
-            .sink { [weak self] balance, state in
-                let subaccountNumber: Int
-                if let subaccount = state.subaccount {
-                    subaccountNumber = Int(subaccount.subaccountNumber)
-                } else {
-                    subaccountNumber = 0
-                }
-                let depositAmount = (balance ?? 0) - dydxTransferSubaccountWorker.balanceRetainAmount
+            .sink { [weak self] balance, walletState in
+                guard let balance, balance > dydxTransferSubaccountWorker.balanceRetainAmount else { return }
+                let depositAmount = balance - dydxTransferSubaccountWorker.balanceRetainAmount
                 let amountString = dydxFormatter.shared.decimalLocaleAgnostic(number: NSNumber(value: depositAmount),
                                                                               digits: dydxTokenConstants.usdcTokenDecimal)
                 if let amountString = amountString {
                     self?.depositToSubaccount(amount: amountString,
-                                              subaccount: subaccountNumber,
-                                              walletState: state.walletState)
+                                              subaccount: AbacusStateManager.shared.selectedSubaccountNumber,
+                                              walletState: walletState)
                 } else {
                     Console.shared.log("dydxTransferSubaccountWorker: Invalid amount")
                 }

--- a/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
+++ b/dydx/dydxStateManager/dydxStateManager/AbacusStateManager.swift
@@ -41,6 +41,10 @@ public final class AbacusStateManager: NSObject {
     public var environment: V4Environment? {
         asyncStateManager.environment
     }
+    
+    public var selectedSubaccountNumber: Int {
+       Int(asyncStateManager.subaccountNumber)
+    }
 
     public var appSetting: AppSetting? {
         asyncStateManager.appSettings?.ios
@@ -134,7 +138,7 @@ public final class AbacusStateManager: NSObject {
 
     private var isStarted = false
 
-    private lazy var asyncStateManager: AsyncAbacusStateManagerProtocol & AsyncAbacusStateManagerSingletonProtocol = {
+    private lazy var asyncStateManager: SingletonAsyncAbacusStateManagerProtocol = {
         UIImplementations.reset(language: nil)
 
         let deployment: String


### PR DESCRIPTION
Linear: [CLI-641: USDC sweep into subaccount does not work for fresh address](https://linear.app/dydx/issue/CLI-641/usdc-sweep-into-subaccount-does-not-work-for-fresh-address)

see corresponding [android change](https://github.com/dydxprotocol/v4-native-android/pull/214) for details