### PR TITLE
fix feature flag initialization ordering

### DIFF
--- a/AmplitudeInjections/AmplitudeInjections/_Tracking/AmplitudeTracking.swift
+++ b/AmplitudeInjections/AmplitudeInjections/_Tracking/AmplitudeTracking.swift
@@ -15,6 +15,7 @@ open class AmplitudeTracking: TransformerTracker {
     
     public init(_ apiKey: String) {
         self.amplitude = Amplitude.init(configuration: .init(apiKey: apiKey))
+        Console.shared.log("analytics log | Amplitude initialized")
         super.init()
     }
     

--- a/StatsigInjections/StatsigInjections/StatsigInjections.swift
+++ b/StatsigInjections/StatsigInjections/StatsigInjections.swift
@@ -98,7 +98,7 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
                     // this may change if we need FF pre-launch
 //                    completion()
                 }
-            Console.shared.log("analytics log | Statsig initialized (local only, async feature flags fetch ongoing)")
+            Console.shared.log("analytics log | Statsig initialized (local only, async feature flags fetch ongoing) | env: \(environment.debugDescription) | userId: \(userId)")
             initializationState = .initializedRemoteLoading
         }
         completion()

--- a/StatsigInjections/StatsigInjections/StatsigInjections.swift
+++ b/StatsigInjections/StatsigInjections/StatsigInjections.swift
@@ -18,7 +18,7 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
     
     private let apiKey: String
     private let userId: String
-    private let environment: StatsigEnvironment
+    private let environment: Environment
     // ensures feature flag values stay constant throughout the app session after they are used the first time, even if they are initialized to null
     private var sessionValues = [String: Availabilty]()
     
@@ -28,7 +28,7 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
         case unavailable
     }
     
-    public enum Environment {
+    public enum Environment: CustomDebugStringConvertible {
         case production
         case development
         
@@ -40,12 +40,21 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
                 return StatsigEnvironment(tier: .Development)
             }
         }
+        
+        public var debugDescription: String {
+            switch self {
+            case .production:
+                return "production"
+            case .development:
+                return "development"
+            }
+        }
     }
     
     public init(apiKey: String, userId: String, environment: Environment) {
         self.apiKey = apiKey
         self.userId = userId
-        self.environment = environment.statsigEnvironemnt
+        self.environment = environment
     }
     
     static public var shared: StatsigFeatureFlagsProvider?
@@ -64,7 +73,7 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
             Statsig.start(sdkKey: apiKey, user: StatsigUser(userID: userId), options: StatsigOptions(
                 initTimeout: nil,
                 disableCurrentVCLogging: true,
-                environment: environment,
+                environment: environment.statsigEnvironemnt,
                 enableAutoValueUpdate: true,
                 autoValueUpdateIntervalSec: nil,
                 overrideStableID: nil,
@@ -79,9 +88,9 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
                 userValidationCallback: nil,
                 customCacheKey: nil,
                 urlSession: nil)) {[weak self] error in
-                    Console.shared.log("Statsig feature flags initialized")
+                    Console.shared.log("analytics log | Statsig feature flags finished initial fetch")
                     if let error {
-                        Console.shared.log("Statsig feature flags failed to initialize: \(error)")
+                        Console.shared.log("analytics log | Statsig feature flags finished initial fetch with error: \(error)")
                         return
                     }
                     self?.initializationState = .initializedRemoteLoaded
@@ -89,6 +98,7 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
                     // this may change if we need FF pre-launch
 //                    completion()
                 }
+            Console.shared.log("analytics log | Statsig initialized (local only, async feature flags fetch ongoing)")
             initializationState = .initializedRemoteLoading
         }
         completion()


### PR DESCRIPTION
## Description / Intuition
- fixes ordering of feature flag initialization and abacus initialization (note this was not affecting outside of DEBUG since the affected feature flag is a debug-only feature flag not managed by statsig)
- adds logging output for analytics initialization




<br/>

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring or Technical Debt
- [ ] Documentation update
- [ ] Other (please describe: )
