### PR TITLE
add `isNativeApp` Statsig user property

### DIFF
--- a/StatsigInjections/StatsigInjections/StatsigInjections.swift
+++ b/StatsigInjections/StatsigInjections/StatsigInjections.swift
@@ -70,7 +70,7 @@ public final class StatsigFeatureFlagsProvider: NSObject, FeatureFlagsProtocol {
             initializationState = .initializedRemoteLoaded
             completion()
         } else {
-            Statsig.start(sdkKey: apiKey, user: StatsigUser(userID: userId), options: StatsigOptions(
+            Statsig.start(sdkKey: apiKey, user: StatsigUser(userID: userId, customIDs: ["isNativeApp":"true"]), options: StatsigOptions(
                 initTimeout: nil,
                 disableCurrentVCLogging: true,
                 environment: environment.statsigEnvironemnt,


### PR DESCRIPTION
## Description / Intuition
As statsig does not offer a way to distinguish native from mobile-web, we must add a [custom property](https://docs.statsig.com/client/iosClientSDK/#statsig-user) to distinguish. 

from Statsig slack channel AI bot:
> The documentation does not provide a specific out-of-the-box method to disambiguate between an iOS native app user and an iOS web-app user. However, you can use the systemName and userAgent fields in the StatsigUser object to help differentiate between the two. The systemName can indicate the operating system, and the userAgent can provide details about the browser, which might help in identifying web-app users. You may need to implement custom logic based on these fields to achieve the disambiguation. If you need further assistance, a Statsig team member will be by to help shortly.

### Creating a Segment With new Property
![Screenshot 2024-10-14 at 3 59 27 PM](https://github.com/user-attachments/assets/e6ff3192-4555-4bcf-9519-d6f99348a9bd)

### Exhibit New User Property
![Screenshot 2024-10-14 at 3 59 13 PM](https://github.com/user-attachments/assets/477d4433-9eb0-47ea-a165-82fb132765c9)

