### PR TITLE
ENG-536 Update UI for the Sep reward program

### DIFF
--- a/dydx/dydxFormatter/dydxFormatter/_Utils/dydxFeatureFlag.swift
+++ b/dydx/dydxFormatter/dydxFormatter/_Utils/dydxFeatureFlag.swift
@@ -16,6 +16,7 @@ public enum dydxBoolFeatureFlag: String, CaseIterable {
     case simple_ui = "ff_simple_ui"
     case privy_ios = "ff_privy_ios"
     case turnkey_ios = "ff_turnkey_ios"
+    case rewards_sep_2025 = "ff_rewards_sep_2025"
 
     var defaultValue: Bool {
         switch self {
@@ -30,6 +31,8 @@ public enum dydxBoolFeatureFlag: String, CaseIterable {
         case .privy_ios:
             return false
         case .turnkey_ios:
+            return false
+        case .rewards_sep_2025:
             return false
         }
     }

--- a/dydx/dydxPresenters/dydxPresenters/_Features/features.json
+++ b/dydx/dydxPresenters/dydxPresenters/_Features/features.json
@@ -112,6 +112,26 @@
                         }
                     ]
                 }
+            },
+            {
+                "title":{
+                    "text":"Rewards Sep 2025"
+                },
+                "field":{
+                    "field":"ff_rewards_sep_2025",
+                    "optional":true,
+                    "type" : "bool",
+                    "options" : [
+                        {
+                            "text": "yes",
+                            "value" : 1
+                        },
+                        {
+                            "text": "no",
+                            "value" : 0
+                        }
+                    ]
+                }
             }
         ]
     }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxAlertsWorker.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/GlobalWorkers/Workers/dydxAlertsWorker.swift
@@ -12,6 +12,7 @@ import Foundation
 import ParticlesKit
 import RoutingKit
 import Utilities
+import dydxFormatter
 
 extension Abacus.NotificationType {
     var infoType: EInfoType {
@@ -53,6 +54,12 @@ final class dydxAlertsWorker: BaseWorker {
             // display alerts in chronological order they were received
             .sorted { $0.updateTimeInMilliseconds < $1.updateTimeInMilliseconds }
             .forEach { alert in
+                // Skip block reward notification for Sep 2025
+                if dydxBoolFeatureFlag.rewards_sep_2025.isEnabled,
+                   alert.id.starts(with: "blockReward:") {
+                    return
+                }
+
                 let link = alert.link
                 let actions = (link != nil) ? [ErrorAction(text: DataLocalizer.localize(path: "APP.GENERAL.VIEW")) {
                     Router.shared?.navigate(to: RoutingRequest(path: link!), animated: true, completion: nil)

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Profile/TradingRewards/Components/dydxRewardsLaunchIncentivesPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Profile/TradingRewards/Components/dydxRewardsLaunchIncentivesPresenter.swift
@@ -25,6 +25,7 @@ public class dydxRewardsLaunchIncentivesPresenter: HostedViewPresenter<dydxRewar
         super.init()
 
         viewModel = dydxRewardsLaunchIncentivesViewModel()
+        viewModel?.isSep2025 = dydxBoolFeatureFlag.rewards_sep_2025.isEnabled
     }
 
     public override func start() {

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Receipt/dydxReceiptPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Receipt/dydxReceiptPresenter.swift
@@ -33,7 +33,7 @@ class dydxReceiptPresenter: HostedViewPresenter<dydxReceiptViewModel>, dydxRecei
     let exchangeRateViewModel = dydxReceiptItemViewModel()
     let exchangeReceivedViewModel = dydxReceiptItemViewModel()
     let slippageViewModel = dydxReceiptItemViewModel()
-    let equlityViewModel = dydxReceiptEquityViewModel()
+    let equityViewModel = dydxReceiptEquityViewModel()
     let rewardsViewModel = dydxReceiptRewardsViewModel()
     let transferDurationViewModel = dydxReceiptItemViewModel()
 
@@ -42,7 +42,7 @@ class dydxReceiptPresenter: HostedViewPresenter<dydxReceiptViewModel>, dydxRecei
 
         viewModel = dydxReceiptViewModel()
 
-        equlityViewModel.usdcTokenName = dydxTokenConstants.usdcTokenName
+        equityViewModel.usdcTokenName = dydxTokenConstants.usdcTokenName
         rewardsViewModel.nativeTokenLogoUrl = dydxTokenConstants.nativeTokenLogoUrl
     }
 
@@ -75,7 +75,7 @@ class dydxReceiptPresenter: HostedViewPresenter<dydxReceiptViewModel>, dydxRecei
             case .positionleverage:
                 return positionLeverageViewModel
             case .equity:
-                return equlityViewModel
+                return equityViewModel
             case .exchangerate:
                 return exchangeRateViewModel
             case .exchangereceived:

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Receipt/dydxTradeReceiptPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Receipt/dydxTradeReceiptPresenter.swift
@@ -58,7 +58,11 @@ final class dydxTradeReceiptPresenter: dydxReceiptPresenter {
                 self?.updatePositionMargin(position: position)
                 self?.updatePositionLeverage(position: position)
                 self?.updateTradingFee(tradeSummary: tradeSummary)
-                self?.updateTradingRewards(tradeSummary: tradeSummary)
+                if dydxBoolFeatureFlag.rewards_sep_2025.isEnabled {
+                    self?.updateTradingRewardsSep2025(tradeSummary: tradeSummary)
+                } else {
+                    self?.updateTradingRewards(tradeSummary: tradeSummary)
+                }
             }
             .store(in: &subscriptions)
 
@@ -138,6 +142,7 @@ final class dydxTradeReceiptPresenter: dydxReceiptPresenter {
     }
 
     private func updateTradingRewards(tradeSummary: TradeInputSummary?) {
+        rewardsViewModel.isSep2025 = false
         guard let rewards = tradeSummary?.reward?.doubleValue,
               let value = dydxFormatter.shared.localFormatted(number: abs(rewards), digits: 6)  else {
             rewardsViewModel.rewards = nil
@@ -151,6 +156,18 @@ final class dydxTradeReceiptPresenter: dydxReceiptPresenter {
         } else {
             rewardsViewModel.rewards = SignedAmountViewModel(text: value, sign: .minus, coloringOption: .signOnly)
         }
+    }
+
+    private func updateTradingRewardsSep2025(tradeSummary: TradeInputSummary?) {
+        rewardsViewModel.isSep2025 = true
+        guard let fee = tradeSummary?.fee?.doubleValue else {
+            rewardsViewModel.rewardsSep2025 = nil
+            return
+        }
+
+        var rewards = max(0.0, fee) * 0.5
+        let amount = dydxFormatter.shared.dollar(number: rewards, digits: 2)
+        rewardsViewModel.rewardsSep2025 = SignedAmountViewModel(text: amount, sign: .none, coloringOption: .signOnly)
     }
 
     private func updateEquityChange(account: Subaccount) {
@@ -167,6 +184,6 @@ final class dydxTradeReceiptPresenter: dydxReceiptPresenter {
             after = nil
         }
 
-        equlityViewModel.equityChange = .init(before: before, after: after)
+        equityViewModel.equityChange = .init(before: before, after: after)
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/Receipt/dydxTransferReceiptViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/Receipt/dydxTransferReceiptViewPresenter.swift
@@ -211,6 +211,6 @@ final class dydxTransferReceiptViewPresenter: dydxReceiptPresenter {
             after = nil
         }
 
-        equlityViewModel.equityChange = .init(before: before, after: after)
+        equityViewModel.equityChange = .init(before: before, after: after)
     }
 }

--- a/dydx/dydxPresenters/dydxPresenters/_v4/SimpleUI/MarketInfo/components/dydxSimpleUiMarketLaunchableViewPresenter.swift
+++ b/dydx/dydxPresenters/dydxPresenters/_v4/SimpleUI/MarketInfo/components/dydxSimpleUiMarketLaunchableViewPresenter.swift
@@ -16,7 +16,6 @@ import dydxStateManager
 import Abacus
 import dydxFormatter
 import SwiftUI
-import Statsig
 
 protocol dydxSimpleUiMarketLaunchableViewPresenterProtocol: HostedViewPresenterProtocol {
     var viewModel: dydxSimpleUiMarketLaunchableViewModel? { get }

--- a/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxRewardsLaunchIncentivesView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Profile/TradingRewards/Components/dydxRewardsLaunchIncentivesView.swift
@@ -15,6 +15,7 @@ public class dydxRewardsLaunchIncentivesViewModel: PlatformViewModel {
     @Published public var points: String?
     @Published public var aboutAction: (() -> Void)?
     @Published public var leaderboardAction: (() -> Void)?
+    @Published public var isSep2025: Bool = false
 
     public static var previewValue: dydxRewardsLaunchIncentivesViewModel = {
         let vm = dydxRewardsLaunchIncentivesViewModel()
@@ -22,11 +23,23 @@ public class dydxRewardsLaunchIncentivesViewModel: PlatformViewModel {
         return vm
     }()
 
-    private let launchIncentivesFormatted: AttributedString = {
-        guard let launchIncentives = DataLocalizer.shared?.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE_HEADLINE", params: nil) else { return .init() }
+    private lazy var launchIncentivesFormatted: AttributedString = {
+        let launchIncentives: String?
+        if isSep2025 {
+            launchIncentives = DataLocalizer.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE") + ": " +
+            DataLocalizer.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE_HEADLINE_SEP_2025",
+                                                      params: [
+                                                        "REWARD_AMOUNT": "$1M",
+                                                        "REBATE_PERCENT": "50%"
+                                                      ])
+        } else {
+            launchIncentives = DataLocalizer.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE_HEADLINE", params: nil)
+        }
+        guard let launchIncentives else { return .init() }
+
         return AttributedString(launchIncentives)
-           .themeFont(fontType: .base, fontSize: .medium)
-           .themeColor(foreground: .textPrimary)
+            .themeFont(fontType: .base, fontSize: .medium)
+            .themeColor(foreground: .textPrimary)
     }()
 
     private var pointsFormatted: AttributedString {
@@ -104,10 +117,22 @@ public class dydxRewardsLaunchIncentivesViewModel: PlatformViewModel {
     public override func createView(parentStyle: ThemeStyle = ThemeStyle.defaultStyle, styleKey: String? = nil) -> PlatformView {
         PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] style  in
             guard let self = self else { return AnyView(PlatformView.nilView) }
+
+            let body: String
+            if self.isSep2025 {
+                body = DataLocalizer.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE_BODY_SEP_2025",
+                                              params: [
+                                                "REWARD_AMOUNT": "$1M",
+                                                "REBATE_PERCENT": "50%"
+                                              ])
+            } else {
+                body = DataLocalizer.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE_BODY", params: nil)
+            }
+
             return VStack(spacing: 16) {
                 self.createEstimateSubCard()
                 VStack(alignment: .leading, spacing: 8) {
-                    HStack {
+                    HStack(alignment: .center) {
                         Text(self.launchIncentivesFormatted)
 
                         Text(DataLocalizer.localize(path: "APP.GENERAL.ACTIVE"))
@@ -119,9 +144,11 @@ public class dydxRewardsLaunchIncentivesViewModel: PlatformViewModel {
 
                         Spacer()
                     }
-                    Text(DataLocalizer.shared?.localize(path: "APP.REWARDS_SURGE_APRIL_2025.SURGE_BODY", params: nil) ?? "")
+
+                    Text(body)
                         .themeFont(fontType: .base, fontSize: .small)
                         .themeColor(foreground: .textTertiary)
+
                     HStack(spacing: 8) {
                         Text(DataLocalizer.shared?.localize(path: "APP.TRADING_REWARDS.POWERED_BY", params: nil) ?? "")
                             .themeFont(fontType: .base, fontSize: .smaller)

--- a/dydx/dydxViews/dydxViews/_v4/Receipt/Components/dydxReceiptRewardsView.swift
+++ b/dydx/dydxViews/dydxViews/_v4/Receipt/Components/dydxReceiptRewardsView.swift
@@ -14,6 +14,15 @@ public class dydxReceiptRewardsViewModel: PlatformViewModel {
     @Published public var rewards: SignedAmountViewModel?
     @Published public var nativeTokenLogoUrl: URL?
 
+    @Published public var isSep2025: Bool = false
+    @Published public var rewardsSep2025: SignedAmountViewModel?
+
+    @Published private var presented: Bool = false
+    private lazy var presentedBindng = Binding(
+        get: { [weak self] in self?.presented == true },
+        set: { [weak self] in self?.presented = $0 }
+    )
+
     public init() { }
 
     public static var previewValue: dydxReceiptRewardsViewModel {
@@ -26,29 +35,86 @@ public class dydxReceiptRewardsViewModel: PlatformViewModel {
         PlatformView(viewModel: self, parentStyle: parentStyle, styleKey: styleKey) { [weak self] style  in
             guard let self = self else { return AnyView(PlatformView.nilView) }
 
-            return AnyView(
-                HStack(spacing: 4) {
-                    Text(DataLocalizer.localize(path: "APP.GENERAL.EST_REWARDS"))
+            if self.isSep2025 {
+                let attributedTitle = AttributedString(DataLocalizer.localize(path: "APP.GENERAL.EST_REWARDS"))
+                    .themeFont(fontSize: .small)
+                    .themeColor(foreground: .textTertiary)
+                let label = Text(attributedTitle.dottedUnderline(foreground: .textTertiary))
+                    .themeColor(foreground: .textTertiary)
+                    .wrappedViewModel
+                let content = VStack(alignment: .leading, spacing: 8) {
+                    Text(DataLocalizer.localize(path: "TRADE.MAXIMUM_REWARDS.BODY",
+                                                params: ["REWARD_AMOUNT": "1M"]))
                         .themeFont(fontSize: .small)
                         .themeColor(foreground: .textTertiary)
-                        .lineLimit(1)
-                    if let nativeTokenLogoUrl = self.nativeTokenLogoUrl {
-                        PlatformIconViewModel(type: .url(url: nativeTokenLogoUrl),
-                                              size: CGSize(width: 18, height: 18))
-                        .createView(parentStyle: style)
-                    }
-
-                    Spacer()
-                    if let rewards = self.rewards {
-                        rewards.createView(parentStyle: style
-                            .themeFont(fontType: .number, fontSize: .small)
-                            .themeColor(foreground: .textPrimary))
-                            .lineLimit(1)
-                    } else {
-                        dydxReceiptEmptyView.emptyValue
-                    }
                 }
-            )
+                let labelView = label.createView(parentStyle: style)
+                    .onTapGesture { [weak self] in
+                        self?.presented.toggle()
+                    }
+                    .popover(present: presentedBindng, attributes: {
+                        $0.position = .absolute(
+                              originAnchor: .top,
+                              popoverAnchor: .bottom
+                          )
+                        $0.sourceFrameInset = .init(top: 0, left: 0, bottom: -16, right: 0)
+                        $0.presentation.animation = .none
+                        $0.blocksBackgroundTouches = true
+                        $0.onTapOutside = { [weak self] in
+                            self?.presented = false
+                        }
+                    }, view: {
+                        content
+                        .padding(.vertical, 10)
+                        .padding(.horizontal, 12)
+                        .themeColor(background: .layer5)
+                        .borderAndClip(style: .cornerRadius(8), borderColor: .layer6, lineWidth: 1)
+                        .environmentObject(ThemeSettings.shared)
+                    })
+
+                return AnyView(
+                    HStack(spacing: 4) {
+                        labelView
+
+                        Spacer()
+
+                        if let rewards = self.rewardsSep2025 {
+                            rewards.createView(parentStyle: style
+                                .themeFont(fontType: .number, fontSize: .small)
+                                .themeColor(foreground: .textPrimary))
+                            .lineLimit(1)
+                        } else {
+                            dydxReceiptEmptyView.emptyValue
+                        }
+
+                    }
+                )
+            } else {
+                return AnyView(
+                    HStack(spacing: 4) {
+                        Text(DataLocalizer.localize(path: "APP.GENERAL.EST_REWARDS"))
+                            .themeFont(fontSize: .small)
+                            .themeColor(foreground: .textTertiary)
+                            .lineLimit(1)
+                        if let nativeTokenLogoUrl = self.nativeTokenLogoUrl {
+                            PlatformIconViewModel(type: .url(url: nativeTokenLogoUrl),
+                                                  size: CGSize(width: 18, height: 18))
+                            .createView(parentStyle: style)
+                        }
+
+                        Spacer()
+
+                        if let rewards = self.rewards {
+                            rewards.createView(parentStyle: style
+                                .themeFont(fontType: .number, fontSize: .small)
+                                .themeColor(foreground: .textPrimary))
+                            .lineLimit(1)
+                        } else {
+                            dydxReceiptEmptyView.emptyValue
+                        }
+                    }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
- Add feature flag
- Disable block reward
- Show receipt line pop-over and use 50% of the estimate fee
- Different text for the trading reward view

| Header | Header |
|--------|--------|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-29 at 21 45 01" src="https://github.com/user-attachments/assets/01cefd8f-20eb-4e2e-a862-7e507d2944ac" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-29 at 21 44 47" src="https://github.com/user-attachments/assets/518ce327-dc8b-4513-a621-cfc2c3839d78" /> | 


